### PR TITLE
Use _len to shortcut around calls to __len__ where available.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ hdfs-initialized-indicator
 .ipynb_checkpoints
 mydask.png
 .vscode/
+env/

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.eggs
 .hypothesis
 *.py[cod]
 __pycache__/

--- a/dask/array/backends.py
+++ b/dask/array/backends.py
@@ -17,6 +17,34 @@ def register_cupy():
         return cupy.einsum(*args, **kwargs)
 
 
+@concatenate_lookup.register_lazy("cupyx")
+def register_cupyx():
+
+    from cupyx.scipy.sparse import spmatrix
+
+    try:
+        from cupy.sparse import hstack
+        from cupy.sparse import vstack
+    except ImportError:
+        raise ImportError(
+            "Stacking of sparse arrays requires at least CuPy version 8.0.0"
+        )
+
+    def _concat_cupy_sparse(L, axis=0):
+        if axis == 0:
+            return vstack(L)
+        elif axis == 1:
+            return hstack(L)
+        else:
+            msg = (
+                "Can only concatenate cupy sparse matrices for axis in "
+                "{0, 1}.  Got %s" % axis
+            )
+            raise ValueError(msg)
+
+    concatenate_lookup.register(spmatrix, _concat_cupy_sparse)
+
+
 @tensordot_lookup.register_lazy("sparse")
 @concatenate_lookup.register_lazy("sparse")
 def register_sparse():

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -412,7 +412,7 @@ def map_blocks(
     drop_axis=[],
     new_axis=None,
     meta=None,
-    **kwargs
+    **kwargs,
 ):
     """ Map a function across all blocks of a dask array.
 
@@ -811,7 +811,7 @@ def store(
     regions=None,
     compute=True,
     return_stored=False,
-    **kwargs
+    **kwargs,
 ):
     """ Store dask arrays in array-like objects, overwrite data in target
 
@@ -2696,6 +2696,15 @@ def from_array(
         changed by installing cityhash, xxhash or murmurhash. If installed,
         a large-factor speedup can be obtained in the tokenisation step.
         Use ``name=False`` to generate a random name instead of hashing (fast)
+
+        .. note::
+
+           Because this ``name`` is used as the key in task graphs, you should
+           ensure that it uniquely identifies the data contained within. If
+           you'd like to provide a descriptive name that is still unique, combine
+           the descriptive name with :func:`dask.base.tokenize` of the
+           ``array_like``. See :ref:`graphs` for more.
+
     lock : bool or Lock, optional
         If ``x`` doesn't support concurrent reads then provide a lock here, or
         pass in True to have dask.array create one for you.
@@ -2731,6 +2740,12 @@ def from_array(
     >>> a = da.from_array(x, chunks='auto')  # doctest: +SKIP
     >>> a = da.from_array(x, chunks='100 MiB')  # doctest: +SKIP
     >>> a = da.from_array(x)  # doctest: +SKIP
+
+    If providing a name, ensure that it is unique
+
+    >>> import dask.base
+    >>> token = dask.base.tokenize(x)  # doctest: +SKIP
+    >>> a = da.from_array('myarray-' + token)  # doctest: +SKIP
     """
     if isinstance(x, Array):
         raise ValueError(
@@ -2852,7 +2867,7 @@ def to_zarr(
     overwrite=False,
     compute=True,
     return_stored=False,
-    **kwargs
+    **kwargs,
 ):
     """Save array to the zarr storage format
 

--- a/dask/array/random.py
+++ b/dask/array/random.py
@@ -75,15 +75,13 @@ class RandomState(object):
     def seed(self, seed=None):
         self._numpy_state.seed(seed)
 
-    def _wrap(self, funcname, *args, **kwargs):
+    def _wrap(
+        self, funcname, *args, size=None, chunks="auto", extra_chunks=(), **kwargs
+    ):
         """ Wrap numpy random function to produce dask.array random function
 
         extra_chunks should be a chunks tuple to append to the end of chunks
         """
-        size = kwargs.pop("size", None)
-        chunks = kwargs.pop("chunks", "auto")
-        extra_chunks = kwargs.pop("extra_chunks", ())
-
         if size is not None and not isinstance(size, (tuple, list)):
             size = (size,)
 
@@ -199,16 +197,16 @@ class RandomState(object):
         return Array(graph, name, chunks + extra_chunks, meta=meta)
 
     @derived_from(np.random.RandomState)
-    def beta(self, a, b, size=None, chunks="auto"):
-        return self._wrap("beta", a, b, size=size, chunks=chunks)
+    def beta(self, a, b, size=None, chunks="auto", **kwargs):
+        return self._wrap("beta", a, b, size=size, chunks=chunks, **kwargs)
 
     @derived_from(np.random.RandomState)
-    def binomial(self, n, p, size=None, chunks="auto"):
-        return self._wrap("binomial", n, p, size=size, chunks=chunks)
+    def binomial(self, n, p, size=None, chunks="auto", **kwargs):
+        return self._wrap("binomial", n, p, size=size, chunks=chunks, **kwargs)
 
     @derived_from(np.random.RandomState)
-    def chisquare(self, df, size=None, chunks="auto"):
-        return self._wrap("chisquare", df, size=size, chunks=chunks)
+    def chisquare(self, df, size=None, chunks="auto", **kwargs):
+        return self._wrap("chisquare", df, size=size, chunks=chunks, **kwargs)
 
     with ignoring(AttributeError):
 
@@ -288,49 +286,49 @@ class RandomState(object):
     # def dirichlet(self, alpha, size=None, chunks="auto"):
 
     @derived_from(np.random.RandomState)
-    def exponential(self, scale=1.0, size=None, chunks="auto"):
-        return self._wrap("exponential", scale, size=size, chunks=chunks)
+    def exponential(self, scale=1.0, size=None, chunks="auto", **kwargs):
+        return self._wrap("exponential", scale, size=size, chunks=chunks, **kwargs)
 
     @derived_from(np.random.RandomState)
-    def f(self, dfnum, dfden, size=None, chunks="auto"):
-        return self._wrap("f", dfnum, dfden, size=size, chunks=chunks)
+    def f(self, dfnum, dfden, size=None, chunks="auto", **kwargs):
+        return self._wrap("f", dfnum, dfden, size=size, chunks=chunks, **kwargs)
 
     @derived_from(np.random.RandomState)
-    def gamma(self, shape, scale=1.0, size=None, chunks="auto"):
-        return self._wrap("gamma", shape, scale, size=size, chunks=chunks)
+    def gamma(self, shape, scale=1.0, size=None, chunks="auto", **kwargs):
+        return self._wrap("gamma", shape, scale, size=size, chunks=chunks, **kwargs)
 
     @derived_from(np.random.RandomState)
-    def geometric(self, p, size=None, chunks="auto"):
-        return self._wrap("geometric", p, size=size, chunks=chunks)
+    def geometric(self, p, size=None, chunks="auto", **kwargs):
+        return self._wrap("geometric", p, size=size, chunks=chunks, **kwargs)
 
     @derived_from(np.random.RandomState)
-    def gumbel(self, loc=0.0, scale=1.0, size=None, chunks="auto"):
-        return self._wrap("gumbel", loc, scale, size=size, chunks=chunks)
+    def gumbel(self, loc=0.0, scale=1.0, size=None, chunks="auto", **kwargs):
+        return self._wrap("gumbel", loc, scale, size=size, chunks=chunks, **kwargs)
 
     @derived_from(np.random.RandomState)
-    def hypergeometric(self, ngood, nbad, nsample, size=None, chunks="auto"):
+    def hypergeometric(self, ngood, nbad, nsample, size=None, chunks="auto", **kwargs):
         return self._wrap(
-            "hypergeometric", ngood, nbad, nsample, size=size, chunks=chunks
+            "hypergeometric", ngood, nbad, nsample, size=size, chunks=chunks, **kwargs
         )
 
     @derived_from(np.random.RandomState)
-    def laplace(self, loc=0.0, scale=1.0, size=None, chunks="auto"):
-        return self._wrap("laplace", loc, scale, size=size, chunks=chunks)
+    def laplace(self, loc=0.0, scale=1.0, size=None, chunks="auto", **kwargs):
+        return self._wrap("laplace", loc, scale, size=size, chunks=chunks, **kwargs)
 
     @derived_from(np.random.RandomState)
-    def logistic(self, loc=0.0, scale=1.0, size=None, chunks="auto"):
-        return self._wrap("logistic", loc, scale, size=size, chunks=chunks)
+    def logistic(self, loc=0.0, scale=1.0, size=None, chunks="auto", **kwargs):
+        return self._wrap("logistic", loc, scale, size=size, chunks=chunks, **kwargs)
 
     @derived_from(np.random.RandomState)
-    def lognormal(self, mean=0.0, sigma=1.0, size=None, chunks="auto"):
-        return self._wrap("lognormal", mean, sigma, size=size, chunks=chunks)
+    def lognormal(self, mean=0.0, sigma=1.0, size=None, chunks="auto", **kwargs):
+        return self._wrap("lognormal", mean, sigma, size=size, chunks=chunks, **kwargs)
 
     @derived_from(np.random.RandomState)
-    def logseries(self, p, size=None, chunks="auto"):
-        return self._wrap("logseries", p, size=size, chunks=chunks)
+    def logseries(self, p, size=None, chunks="auto", **kwargs):
+        return self._wrap("logseries", p, size=size, chunks=chunks, **kwargs)
 
     @derived_from(np.random.RandomState)
-    def multinomial(self, n, pvals, size=None, chunks="auto"):
+    def multinomial(self, n, pvals, size=None, chunks="auto", **kwargs):
         return self._wrap(
             "multinomial",
             n,
@@ -341,24 +339,28 @@ class RandomState(object):
         )
 
     @derived_from(np.random.RandomState)
-    def negative_binomial(self, n, p, size=None, chunks="auto"):
-        return self._wrap("negative_binomial", n, p, size=size, chunks=chunks)
+    def negative_binomial(self, n, p, size=None, chunks="auto", **kwargs):
+        return self._wrap("negative_binomial", n, p, size=size, chunks=chunks, **kwargs)
 
     @derived_from(np.random.RandomState)
-    def noncentral_chisquare(self, df, nonc, size=None, chunks="auto"):
-        return self._wrap("noncentral_chisquare", df, nonc, size=size, chunks=chunks)
+    def noncentral_chisquare(self, df, nonc, size=None, chunks="auto", **kwargs):
+        return self._wrap(
+            "noncentral_chisquare", df, nonc, size=size, chunks=chunks, **kwargs
+        )
 
     @derived_from(np.random.RandomState)
-    def noncentral_f(self, dfnum, dfden, nonc, size=None, chunks="auto"):
-        return self._wrap("noncentral_f", dfnum, dfden, nonc, size=size, chunks=chunks)
+    def noncentral_f(self, dfnum, dfden, nonc, size=None, chunks="auto", **kwargs):
+        return self._wrap(
+            "noncentral_f", dfnum, dfden, nonc, size=size, chunks=chunks, **kwargs
+        )
 
     @derived_from(np.random.RandomState)
-    def normal(self, loc=0.0, scale=1.0, size=None, chunks="auto"):
-        return self._wrap("normal", loc, scale, size=size, chunks=chunks)
+    def normal(self, loc=0.0, scale=1.0, size=None, chunks="auto", **kwargs):
+        return self._wrap("normal", loc, scale, size=size, chunks=chunks, **kwargs)
 
     @derived_from(np.random.RandomState)
-    def pareto(self, a, size=None, chunks="auto"):
-        return self._wrap("pareto", a, size=size, chunks=chunks)
+    def pareto(self, a, size=None, chunks="auto", **kwargs):
+        return self._wrap("pareto", a, size=size, chunks=chunks, **kwargs)
 
     @derived_from(np.random.RandomState)
     def permutation(self, x):
@@ -372,78 +374,84 @@ class RandomState(object):
         return shuffle_slice(x, index)
 
     @derived_from(np.random.RandomState)
-    def poisson(self, lam=1.0, size=None, chunks="auto"):
-        return self._wrap("poisson", lam, size=size, chunks=chunks)
+    def poisson(self, lam=1.0, size=None, chunks="auto", **kwargs):
+        return self._wrap("poisson", lam, size=size, chunks=chunks, **kwargs)
 
     @derived_from(np.random.RandomState)
-    def power(self, a, size=None, chunks="auto"):
-        return self._wrap("power", a, size=size, chunks=chunks)
+    def power(self, a, size=None, chunks="auto", **kwargs):
+        return self._wrap("power", a, size=size, chunks=chunks, **kwargs)
 
     @derived_from(np.random.RandomState)
-    def randint(self, low, high=None, size=None, chunks="auto", dtype="l"):
-        return self._wrap("randint", low, high, size=size, chunks=chunks, dtype=dtype)
+    def randint(self, low, high=None, size=None, chunks="auto", dtype="l", **kwargs):
+        return self._wrap(
+            "randint", low, high, size=size, chunks=chunks, dtype=dtype, **kwargs
+        )
 
     @derived_from(np.random.RandomState)
-    def random_integers(self, low, high=None, size=None, chunks="auto"):
-        return self._wrap("random_integers", low, high, size=size, chunks=chunks)
+    def random_integers(self, low, high=None, size=None, chunks="auto", **kwargs):
+        return self._wrap(
+            "random_integers", low, high, size=size, chunks=chunks, **kwargs
+        )
 
     @derived_from(np.random.RandomState)
-    def random_sample(self, size=None, chunks="auto"):
-        return self._wrap("random_sample", size=size, chunks=chunks)
+    def random_sample(self, size=None, chunks="auto", **kwargs):
+        return self._wrap("random_sample", size=size, chunks=chunks, **kwargs)
 
     random = random_sample
 
     @derived_from(np.random.RandomState)
-    def rayleigh(self, scale=1.0, size=None, chunks="auto"):
-        return self._wrap("rayleigh", scale, size=size, chunks=chunks)
+    def rayleigh(self, scale=1.0, size=None, chunks="auto", **kwargs):
+        return self._wrap("rayleigh", scale, size=size, chunks=chunks, **kwargs)
 
     @derived_from(np.random.RandomState)
-    def standard_cauchy(self, size=None, chunks="auto"):
-        return self._wrap("standard_cauchy", size=size, chunks=chunks)
+    def standard_cauchy(self, size=None, chunks="auto", **kwargs):
+        return self._wrap("standard_cauchy", size=size, chunks=chunks, **kwargs)
 
     @derived_from(np.random.RandomState)
-    def standard_exponential(self, size=None, chunks="auto"):
-        return self._wrap("standard_exponential", size=size, chunks=chunks)
+    def standard_exponential(self, size=None, chunks="auto", **kwargs):
+        return self._wrap("standard_exponential", size=size, chunks=chunks, **kwargs)
 
     @derived_from(np.random.RandomState)
-    def standard_gamma(self, shape, size=None, chunks="auto"):
-        return self._wrap("standard_gamma", shape, size=size, chunks=chunks)
+    def standard_gamma(self, shape, size=None, chunks="auto", **kwargs):
+        return self._wrap("standard_gamma", shape, size=size, chunks=chunks, **kwargs)
 
     @derived_from(np.random.RandomState)
-    def standard_normal(self, size=None, chunks="auto"):
-        return self._wrap("standard_normal", size=size, chunks=chunks)
+    def standard_normal(self, size=None, chunks="auto", **kwargs):
+        return self._wrap("standard_normal", size=size, chunks=chunks, **kwargs)
 
     @derived_from(np.random.RandomState)
-    def standard_t(self, df, size=None, chunks="auto"):
-        return self._wrap("standard_t", df, size=size, chunks=chunks)
+    def standard_t(self, df, size=None, chunks="auto", **kwargs):
+        return self._wrap("standard_t", df, size=size, chunks=chunks, **kwargs)
 
     @derived_from(np.random.RandomState)
-    def tomaxint(self, size=None, chunks="auto"):
-        return self._wrap("tomaxint", size=size, chunks=chunks)
+    def tomaxint(self, size=None, chunks="auto", **kwargs):
+        return self._wrap("tomaxint", size=size, chunks=chunks, **kwargs)
 
     @derived_from(np.random.RandomState)
-    def triangular(self, left, mode, right, size=None, chunks="auto"):
-        return self._wrap("triangular", left, mode, right, size=size, chunks=chunks)
+    def triangular(self, left, mode, right, size=None, chunks="auto", **kwargs):
+        return self._wrap(
+            "triangular", left, mode, right, size=size, chunks=chunks, **kwargs
+        )
 
     @derived_from(np.random.RandomState)
-    def uniform(self, low=0.0, high=1.0, size=None, chunks="auto"):
-        return self._wrap("uniform", low, high, size=size, chunks=chunks)
+    def uniform(self, low=0.0, high=1.0, size=None, chunks="auto", **kwargs):
+        return self._wrap("uniform", low, high, size=size, chunks=chunks, **kwargs)
 
     @derived_from(np.random.RandomState)
-    def vonmises(self, mu, kappa, size=None, chunks="auto"):
-        return self._wrap("vonmises", mu, kappa, size=size, chunks=chunks)
+    def vonmises(self, mu, kappa, size=None, chunks="auto", **kwargs):
+        return self._wrap("vonmises", mu, kappa, size=size, chunks=chunks, **kwargs)
 
     @derived_from(np.random.RandomState)
-    def wald(self, mean, scale, size=None, chunks="auto"):
-        return self._wrap("wald", mean, scale, size=size, chunks=chunks)
+    def wald(self, mean, scale, size=None, chunks="auto", **kwargs):
+        return self._wrap("wald", mean, scale, size=size, chunks=chunks, **kwargs)
 
     @derived_from(np.random.RandomState)
-    def weibull(self, a, size=None, chunks="auto"):
-        return self._wrap("weibull", a, size=size, chunks=chunks)
+    def weibull(self, a, size=None, chunks="auto", **kwargs):
+        return self._wrap("weibull", a, size=size, chunks=chunks, **kwargs)
 
     @derived_from(np.random.RandomState)
-    def zipf(self, a, size=None, chunks="auto"):
-        return self._wrap("zipf", a, size=size, chunks=chunks)
+    def zipf(self, a, size=None, chunks="auto", **kwargs):
+        return self._wrap("zipf", a, size=size, chunks=chunks, **kwargs)
 
 
 def _choice(state_data, a, size, replace, p):

--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -808,6 +808,12 @@ def round(a, decimals=0):
     return a.map_blocks(np.round, decimals=decimals, dtype=a.dtype)
 
 
+@implements(np.iscomplexobj)
+@derived_from(np)
+def iscomplexobj(x):
+    return issubclass(x.dtype.type, np.complexfloating)
+
+
 def _unique_internal(ar, indices, counts, return_inverse=False):
     """
     Helper/wrapper function for :func:`numpy.unique`.

--- a/dask/array/tests/test_cupy.py
+++ b/dask/array/tests/test_cupy.py
@@ -815,6 +815,19 @@ def test_sfqr(m, n, chunks, error_type):
             q, r = da.linalg.sfqr(data)
 
 
+def test_sparse_hstack_vstack_csr():
+    pytest.importorskip("cupyx")
+    x = cupy.arange(24, dtype=cupy.float32).reshape(4, 6)
+
+    sp = da.from_array(x, chunks=(2, 3), asarray=False, fancy=False)
+    sp = sp.map_blocks(cupy.sparse.csr_matrix, dtype=cupy.float32)
+
+    y = sp.compute()
+
+    assert cupy.sparse.isspmatrix(y)
+    assert_eq(x, y.todense())
+
+
 @pytest.mark.xfail(reason="no shape argument support *_like functions on CuPy yet")
 @pytest.mark.skipif(
     np.__version__ < "1.17", reason="no shape argument for *_like functions"

--- a/dask/array/tests/test_random.py
+++ b/dask/array/tests/test_random.py
@@ -364,3 +364,18 @@ def test_doc_wraps_deprecated():
         @da.random.doc_wraps(np.random.normal)
         def f():
             pass
+
+
+def test_raises_bad_kwarg():
+    with pytest.raises(Exception) as info:
+        da.random.standard_normal(size=(10,), dtype="float64")
+
+    assert "dtype" in str(info.value)
+
+
+def test_randomstate_kwargs():
+    cupy = pytest.importorskip("cupy")
+
+    rs = da.random.RandomState(RandomState=cupy.random.RandomState)
+    x = rs.standard_normal((10, 5), dtype=np.float32)
+    assert x.dtype == np.float32

--- a/dask/array/tests/test_routines.py
+++ b/dask/array/tests/test_routines.py
@@ -1740,3 +1740,11 @@ def test_average_raises():
 
     with pytest.warns(RuntimeWarning):
         da.average(d_a, weights=da.zeros_like(d_a)).compute()
+
+
+def test_iscomplexobj():
+    a = da.from_array(np.array([1, 2]), 2)
+    assert np.iscomplexobj(a) is False
+
+    a = da.from_array(np.array([1, 2 + 0j]), 2)
+    assert np.iscomplexobj(a) is True

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -527,6 +527,8 @@ Dask Name: {name}, {task} tasks"""
         )
 
     def __len__(self):
+        if hasattr(self, "_len"):
+            return self._len
         return self.reduction(
             len, np.sum, token="len", meta=int, split_every=False
         ).compute()
@@ -3342,6 +3344,8 @@ class DataFrame(_Frame):
         return _iLocIndexer(self)
 
     def __len__(self):
+        if hasattr(self, "_len"):
+            return self._len
         try:
             s = self[self.columns[0]]
         except IndexError:

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -527,8 +527,9 @@ Dask Name: {name}, {task} tasks"""
         )
 
     def __len__(self):
-        if hasattr(self, "_len"):
-            return self._len
+        _len = getattr(self, "_len", None)
+        if _len is not None:
+            return _len
         return self.reduction(
             len, np.sum, token="len", meta=int, split_every=False
         ).compute()
@@ -3344,8 +3345,9 @@ class DataFrame(_Frame):
         return _iLocIndexer(self)
 
     def __len__(self):
-        if hasattr(self, "_len"):
-            return self._len
+        _len = getattr(self, "_len", None)
+        if _len is not None:
+            return _len
         try:
             s = self[self.columns[0]]
         except IndexError:

--- a/dask/dataframe/io/hdf.py
+++ b/dask/dataframe/io/hdf.py
@@ -473,6 +473,20 @@ def read_hdf(
         paths = sorted(glob(pattern))
     else:
         paths = pattern
+
+    if not isinstance(pattern, str) and len(paths) == 0:
+        raise ValueError("No files provided")
+    if not paths or len(paths) == 0:
+        raise IOError("File(s) not found: {0}".format(pattern))
+    for path in paths:
+        try:
+            exists = os.path.exists(path)
+        except (ValueError, TypeError):
+            exists = False
+        if not exists:
+            raise IOError(
+                "File not found or insufficient permissions: {0}".format(path)
+            )
     if (start != 0 or stop is not None) and len(paths) > 1:
         raise NotImplementedError(read_hdf_error_msg)
     if chunksize <= 0:

--- a/dask/dataframe/io/io.py
+++ b/dask/dataframe/io/io.py
@@ -183,8 +183,6 @@ def from_pandas(data, npartitions=None, chunksize=None, sort=True, name=None):
 
     if chunksize is None:
         chunksize = int(ceil(nrows / npartitions))
-    else:
-        npartitions = int(ceil(nrows / chunksize))
 
     name = name or ("from_pandas-" + tokenize(data, chunksize))
 

--- a/dask/dataframe/io/parquet/arrow.py
+++ b/dask/dataframe/io/parquet/arrow.py
@@ -1,10 +1,12 @@
 from functools import partial
 from collections import OrderedDict
 import json
+import warnings
 
 import pandas as pd
 import pyarrow as pa
 import pyarrow.parquet as pq
+from pyarrow.compat import guid
 from ....utils import natural_sort_key, getargspec
 from ..utils import _get_pyarrow_dtypes, _meta_from_dtypes
 from ...utils import clear_known_categories
@@ -59,6 +61,37 @@ def _get_row_groups_per_piece(pieces, metadata, path, fs):
         else:
             return None  # File path is missing, abort
     return tuple(result.values())
+
+
+def _merge_statistics(stats, s):
+    """ Update `stats` with vaules in `s`
+    """
+    stats[-1]["total_byte_size"] += s["total_byte_size"]
+    stats[-1]["num-rows"] += s["num-rows"]
+    ncols = len(stats[-1]["columns"])
+    ncols_n = len(s["columns"])
+    if ncols != ncols_n:
+        raise ValueError(f"Column count not equal ({ncols} vs {ncols_n})")
+    for i in range(ncols):
+        name = stats[-1]["columns"][i]["name"]
+        j = i
+        for ii in range(ncols):
+            if name == s["columns"][j]["name"]:
+                break
+            if ii == ncols - 1:
+                raise KeyError(f"Column statistics missing for {name}")
+            j = (j + 1) % ncols
+
+        min_n = s["columns"][j]["min"]
+        max_n = s["columns"][j]["max"]
+        null_count_n = s["columns"][j]["null_count"]
+
+        min_i = stats[-1]["columns"][i]["min"]
+        max_i = stats[-1]["columns"][i]["max"]
+        stats[-1]["columns"][i]["min"] = min(min_i, min_n)
+        stats[-1]["columns"][i]["max"] = min(max_i, max_n)
+        stats[-1]["columns"][i]["null_count"] += null_count_n
+    return True
 
 
 def _determine_dataset_parts(fs, paths, gather_statistics, filters, dataset_kwargs):
@@ -119,6 +152,55 @@ def _determine_dataset_parts(fs, paths, gather_statistics, filters, dataset_kwar
     return parts, dataset
 
 
+def _write_partitioned(
+    table, root_path, partition_cols, fs, preserve_index=True, **kwargs
+):
+    """ Write table to a partitioned dataset with pyarrow.
+
+        Logic copied from pyarrow.parquet.
+        (arrow/python/pyarrow/parquet.py::write_to_dataset)
+
+        TODO: Remove this in favor of pyarrow's `write_to_dataset`
+              once ARROW-8244 is addressed.
+    """
+    fs.mkdirs(root_path, exist_ok=True)
+
+    df = table.to_pandas(ignore_metadata=True)
+    partition_keys = [df[col] for col in partition_cols]
+    data_df = df.drop(partition_cols, axis="columns")
+    data_cols = df.columns.drop(partition_cols)
+    if len(data_cols) == 0 and not preserve_index:
+        raise ValueError("No data left to save outside partition columns")
+
+    subschema = table.schema
+    for col in table.schema.names:
+        if col in partition_cols:
+            subschema = subschema.remove(subschema.get_field_index(col))
+
+    md_list = []
+    for keys, subgroup in data_df.groupby(partition_keys):
+        if not isinstance(keys, tuple):
+            keys = (keys,)
+        subdir = fs.sep.join(
+            [
+                "{colname}={value}".format(colname=name, value=val)
+                for name, val in zip(partition_cols, keys)
+            ]
+        )
+        subtable = pa.Table.from_pandas(
+            subgroup, preserve_index=False, schema=subschema, safe=False
+        )
+        prefix = fs.sep.join([root_path, subdir])
+        fs.mkdir(prefix, exists_ok=True)
+        outfile = guid() + ".parquet"
+        full_path = fs.sep.join([prefix, outfile])
+        with fs.open(full_path, "wb") as f:
+            pq.write_table(subtable, f, metadata_collector=md_list, **kwargs)
+        md_list[-1].set_file_path(fs.sep.join([subdir, outfile]))
+
+    return md_list
+
+
 class ArrowEngine(Engine):
     @staticmethod
     def read_metadata(
@@ -138,6 +220,15 @@ class ArrowEngine(Engine):
         parts, dataset = _determine_dataset_parts(
             fs, paths, gather_statistics, filters, kwargs.get("dataset", {})
         )
+        # Check if the column-chunk file_path's are set in "_metadata".
+        # If available, we can use the path to sort the row-groups
+        col_chunk_paths = False
+        if dataset.metadata:
+            col_chunk_paths = all(
+                dataset.metadata.row_group(i).column(0).file_path is not None
+                for i in range(dataset.metadata.num_row_groups)
+            )
+
         # TODO: Call to `_determine_dataset_parts` uses `pq.ParquetDataset`
         # to define the `dataset` object. `split_row_groups` should be passed
         # to that constructor once it is supported (see ARROW-2801).
@@ -145,10 +236,38 @@ class ArrowEngine(Engine):
             partitions = [
                 n for n in dataset.partitions.partition_names if n is not None
             ]
-            if partitions:
-                split_row_groups = False
+            if partitions and dataset.metadata:
+                # Dont use dataset.metadata for partitioned datasets, unless
+                # the column-chunk metadata includes the `"file_path"`.
+                # The order of dataset.metadata.row_group items is often
+                # different than the order of `dataset.pieces`.
+                if not col_chunk_paths or (
+                    len(dataset.pieces) != dataset.metadata.num_row_groups
+                ):
+                    dataset.schema = dataset.metadata.schema
+                    dataset.metadata = None
         else:
             partitions = []
+
+        # Statistics are currently collected at the row-group level only.
+        # Therefore, we cannot perform filtering with split_row_groups=False.
+        # For "partitioned" datasets, each file (usually) corresponds to a
+        # row-group anyway.
+        # TODO: Map row-group statistics onto file pieces for filtering.
+        #       This shouldn't be difficult if `col_chunk_paths==True`
+        if not split_row_groups and not col_chunk_paths:
+            if gather_statistics is None and not partitions:
+                gather_statistics = False
+                if filters:
+                    raise ValueError(
+                        "Filters not supported with split_row_groups=False "
+                        "(unless proper _metadata is available)."
+                    )
+            if gather_statistics and not partitions:
+                raise ValueError(
+                    "Statistics not supported with split_row_groups=False."
+                    "(unless proper _metadata is available)."
+                )
 
         if dataset.metadata:
             schema = dataset.metadata.schema.to_arrow_schema()
@@ -218,11 +337,20 @@ class ArrowEngine(Engine):
             and dataset.metadata.num_row_groups >= len(pieces)
         ):
             gather_statistics = True
-            # Don't gather stats by default if this is a partitioned dataset
-            if dataset.metadata.num_row_groups != len(pieces) and partitions:
-                gather_statistics = False
         if not pieces:
             gather_statistics = False
+
+        if filters:
+            # Filters may require us to gather statistics
+            if gather_statistics is False and partitions:
+                warnings.warn(
+                    "Filtering with gather_statistics=False. "
+                    "Only partition columns will be filtered correctly."
+                )
+            elif gather_statistics is False:
+                raise ValueError("Cannot apply filters with gather_statistics=False")
+            elif not gather_statistics:
+                gather_statistics = True
 
         row_groups_per_piece = None
         if gather_statistics:
@@ -232,6 +360,16 @@ class ArrowEngine(Engine):
                     dataset.metadata.row_group(i)
                     for i in range(dataset.metadata.num_row_groups)
                 ]
+
+                # Re-order row-groups by path name if known
+                if col_chunk_paths:
+                    row_groups = sorted(
+                        row_groups,
+                        key=lambda row_group: natural_sort_key(
+                            row_group.column(0).file_path
+                        ),
+                    )
+
                 if split_row_groups and len(dataset.paths) == 1:
                     row_groups_per_piece = _get_row_groups_per_piece(
                         pieces, dataset.metadata, dataset.paths[0], fs
@@ -250,6 +388,7 @@ class ArrowEngine(Engine):
         if gather_statistics:
             stats = []
             skip_cols = set()  # Columns with min/max = None detected
+            path_last = None
             for ri, row_group in enumerate(row_groups):
                 s = {"num-rows": row_group.num_rows, "columns": []}
                 for i, name in enumerate(names):
@@ -274,6 +413,17 @@ class ArrowEngine(Engine):
                             )
                         s["columns"].append(d)
                 s["total_byte_size"] = row_group.total_byte_size
+                if col_chunk_paths:
+                    s["file_path_0"] = row_group.column(0).file_path
+                    if not split_row_groups and (s["file_path_0"] == path_last):
+                        # Rather than appending a new "row-group", just merge
+                        # new `s` statistics into last element of `stats`.
+                        # Note that each stats element will now correspond to an
+                        # entire file (rather than actual "row-groups")
+                        _merge_statistics(stats, s)
+                        continue
+                    else:
+                        path_last = s["file_path_0"]
                 stats.append(s)
         else:
             stats = None
@@ -307,7 +457,8 @@ class ArrowEngine(Engine):
                         parts.append((piece.path, rg, piece.partition_keys))
                         # Setting file_path here, because it may be
                         # missing from the row-group/column-chunk stats
-                        stats[rg_tot]["file_path_0"] = piece.path
+                        if "file_path_0" not in stats[rg_tot]:
+                            stats[rg_tot]["file_path_0"] = piece.path
                         rg_tot += 1
             else:
                 parts = [
@@ -484,22 +635,22 @@ class ArrowEngine(Engine):
         schema=None,
         **kwargs,
     ):
-        md_list = []
+        _meta = None
         preserve_index = False
         if index_cols:
             df = df.set_index(index_cols)
             preserve_index = True
         t = pa.Table.from_pandas(df, preserve_index=preserve_index, schema=schema)
         if partition_on:
-            pq.write_to_dataset(
-                t,
-                path,
-                partition_cols=partition_on,
-                filesystem=fs,
-                metadata_collector=md_list,
-                **kwargs,
+            md_list = _write_partitioned(
+                t, path, partition_on, fs, preserve_index=preserve_index, **kwargs
             )
+            if md_list:
+                _meta = md_list[0]
+                for i in range(1, len(md_list)):
+                    _meta.append_row_groups(md_list[i])
         else:
+            md_list = []
             with fs.open(fs.sep.join([path, filename]), "wb") as fil:
                 pq.write_table(
                     t,
@@ -509,10 +660,11 @@ class ArrowEngine(Engine):
                     **kwargs,
                 )
             if md_list:
-                md_list[0].set_file_path(filename)
+                _meta = md_list[0]
+                _meta.set_file_path(filename)
         # Return the schema needed to write the metadata
         if return_metadata:
-            return [{"schema": t.schema, "meta": md_list[0]}]
+            return [{"schema": t.schema, "meta": _meta}]
         else:
             return []
 

--- a/dask/dataframe/io/tests/test_hdf.py
+++ b/dask/dataframe/io/tests/test_hdf.py
@@ -829,3 +829,18 @@ def test_hdf_filenames():
     assert ddf.to_hdf("foo*.hdf5", "key") == ["foo0.hdf5", "foo1.hdf5"]
     os.remove("foo0.hdf5")
     os.remove("foo1.hdf5")
+
+
+def test_hdf_path_exceptions():
+
+    # single file doesn't exist
+    with pytest.raises(IOError):
+        dd.read_hdf("nonexistant_store_X34HJK", "/tmp")
+
+    # a file from a list of files doesn't exist
+    with pytest.raises(IOError):
+        dd.read_hdf(["nonexistant_store_X34HJK", "nonexistant_store_UY56YH"], "/tmp")
+
+    # list of files is empty
+    with pytest.raises(ValueError):
+        dd.read_hdf([], "/tmp")

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -639,7 +639,9 @@ def test_append_with_partition(tmpdir, engine):
         engine=engine,
     )
 
-    out = dd.read_parquet(tmp, engine=engine, gather_statistics=True).compute()
+    out = dd.read_parquet(
+        tmp, engine=engine, index="index", gather_statistics=True
+    ).compute()
     out["lon"] = out.lon.astype("int")  # just to pass assert
     # sort required since partitioning breaks index order
     assert_eq(
@@ -1000,9 +1002,14 @@ def test_to_parquet_pyarrow_w_inconsistent_schema_by_partition_succeeds_w_manual
             ("partition_column", pa.int64()),
         ]
     )
-    ddf.to_parquet(
-        str(tmpdir), engine="pyarrow", partition_on="partition_column", schema=schema
+    fut = ddf.to_parquet(
+        str(tmpdir),
+        compute=False,
+        engine="pyarrow",
+        partition_on="partition_column",
+        schema=schema,
     )
+    fut.compute(scheduler="single-threaded")
     ddf_after_write = (
         dd.read_parquet(str(tmpdir), engine="pyarrow", gather_statistics=False)
         .compute()
@@ -1091,7 +1098,7 @@ def test_partition_on_string(tmpdir, partition_on):
         assert set(df.bb[df.aa == val]) == set(out.bb[out.aa == val])
 
 
-@write_read_engines_xfail
+@write_read_engines()
 def test_filters_categorical(tmpdir, write_engine, read_engine):
     tmpdir = str(tmpdir)
     cats = ["2018-01-01", "2018-01-02", "2018-01-03", "2018-01-04"]
@@ -1104,7 +1111,10 @@ def test_filters_categorical(tmpdir, write_engine, read_engine):
     ddftest = dd.from_pandas(dftest, npartitions=4).set_index("dummy")
     ddftest.to_parquet(tmpdir, partition_on="DatePart", engine=write_engine)
     ddftest_read = dd.read_parquet(
-        tmpdir, engine=read_engine, filters=[(("DatePart", "<=", "2018-01-02"))]
+        tmpdir,
+        index="dummy",
+        engine=read_engine,
+        filters=[(("DatePart", "<=", "2018-01-02"))],
     )
     assert len(ddftest_read) == 2
 
@@ -1762,9 +1772,9 @@ def test_arrow_partitioning(tmpdir):
     }
     pdf = pd.DataFrame(data)
     ddf = dd.from_pandas(pdf, npartitions=2)
-    ddf.to_parquet(path, engine="pyarrow", partition_on="p")
+    ddf.to_parquet(path, engine="pyarrow", write_index=False, partition_on="p")
 
-    ddf = dd.read_parquet(path, engine="pyarrow")
+    ddf = dd.read_parquet(path, index=False, engine="pyarrow")
 
     ddf.astype({"b": np.float32}).compute()
 
@@ -2122,6 +2132,36 @@ def test_split_row_groups_pyarrow(tmpdir):
     assert ddf3.npartitions == 4
 
 
+def test_split_row_groups_filter_pyarrow(tmpdir):
+    check_pyarrow()
+    tmp = str(tmpdir)
+    df = pd.DataFrame(
+        {"i32": np.arange(800, dtype=np.int32), "f": np.arange(800, dtype=np.float64)}
+    )
+    df.index.name = "index"
+    search_val = 600
+    filters = [("f", "==", search_val)]
+
+    dd.from_pandas(df, npartitions=4).to_parquet(
+        tmp, append=True, engine="pyarrow", row_group_size=50
+    )
+
+    ddf2 = dd.read_parquet(tmp, engine="pyarrow")
+    ddf3 = dd.read_parquet(
+        tmp,
+        engine="pyarrow",
+        gather_statistics=True,
+        split_row_groups=False,
+        filters=filters,
+    )
+
+    assert search_val in ddf3["i32"]
+    assert_eq(
+        ddf2[ddf2["i32"] == search_val].compute(),
+        ddf3[ddf3["i32"] == search_val].compute(),
+    )
+
+
 def test_optimize_getitem_and_nonblockwise(tmpdir):
     check_engine()
     path = os.path.join(tmpdir, "path.parquet")
@@ -2260,3 +2300,32 @@ def test_read_parquet_getitem_skip_when_getting_getitem(tmpdir, engine):
 
     ddf = dd.read_parquet(path, engine=engine)
     a, b = dask.optimize(ddf["A"], ddf)
+
+
+@pytest.mark.parametrize("gather_statistics", [None, True])
+@write_read_engines()
+def test_filter_nonpartition_columns(
+    tmpdir, write_engine, read_engine, gather_statistics
+):
+    tmpdir = str(tmpdir)
+    df_write = pd.DataFrame(
+        {
+            "id": [1, 2, 3, 4] * 4,
+            "time": np.arange(16),
+            "random": np.random.choice(["cat", "dog"], size=16),
+        }
+    )
+    ddf_write = dd.from_pandas(df_write, npartitions=4)
+    ddf_write.to_parquet(
+        tmpdir, write_index=False, partition_on=["id"], engine=write_engine
+    )
+    ddf_read = dd.read_parquet(
+        tmpdir,
+        index=False,
+        engine=read_engine,
+        gather_statistics=gather_statistics,
+        filters=[(("time", "<", 5))],
+    )
+    df_read = ddf_read.compute()
+    assert len(df_read) == len(df_read[df_read["time"] < 5])
+    assert df_read["time"].max() < 5

--- a/dask/dataframe/multi.py
+++ b/dask/dataframe/multi.py
@@ -59,7 +59,7 @@ import warnings
 from tlz import merge_sorted, unique, first
 import numpy as np
 import pandas as pd
-from pandas.api.types import is_dtype_equal
+from pandas.api.types import is_dtype_equal, is_categorical_dtype
 
 from ..base import tokenize, is_dask_collection
 from ..highlevelgraph import HighLevelGraph
@@ -80,7 +80,12 @@ from .core import (
 from .io import from_pandas
 from . import methods
 from .shuffle import shuffle, rearrange_by_divisions
-from .utils import strip_unknown_categories, is_series_like, asciitable
+from .utils import (
+    strip_unknown_categories,
+    is_series_like,
+    asciitable,
+    is_dataframe_like,
+)
 
 
 def align_partitions(*dfs):
@@ -931,8 +936,24 @@ def stack_partitions(dfs, divisions, join="outer"):
     for df in dfs:
         # dtypes of all dfs need to be coherent
         # refer to https://github.com/dask/dask/issues/4685
+        # and https://github.com/dask/dask/issues/5968.
+        if is_dataframe_like(df):
+
+            shared_columns = df.columns.intersection(meta.columns)
+            needs_astype = [
+                col
+                for col in shared_columns
+                if df[col].dtype != meta[col].dtype
+                and not is_categorical_dtype(df[col].dtype)
+            ]
+
+            if needs_astype:
+                # Copy to avoid mutating the caller inplace
+                df = df.copy()
+                df[needs_astype] = df[needs_astype].astype(meta[needs_astype].dtypes)
+
         if is_series_like(df) and is_series_like(meta):
-            if not df.dtype == meta.dtype and str(df.dtype) != "category":
+            if not df.dtype == meta.dtype and not is_categorical_dtype(df.dtype):
                 df = df.astype(meta.dtype)
         else:
             pass  # TODO: there are other non-covered cases here

--- a/dask/dataframe/tests/test_arithmetics_reduction.py
+++ b/dask/dataframe/tests/test_arithmetics_reduction.py
@@ -549,7 +549,7 @@ def test_scalar_arithmetics_with_dask_instances():
 
 
 @pytest.mark.xfail(
-    PANDAS_VERSION >= "1.0.2",
+    PANDAS_VERSION == "1.0.2",
     reason="https://github.com/pandas-dev/pandas/issues/32685",
 )
 def test_frame_series_arithmetic_methods():

--- a/dask/dataframe/tests/test_multi.py
+++ b/dask/dataframe/tests/test_multi.py
@@ -1,6 +1,5 @@
 import warnings
 
-import dask
 import dask.dataframe as dd
 import numpy as np
 import pandas as pd
@@ -581,26 +580,36 @@ def test_concat(join):
         assert_eq(result, expected)
 
 
-@pytest.mark.parametrize("join", ["inner", "outer"])
-def test_concat_different_dtypes(join):
+@pytest.mark.parametrize(
+    "value_1, value_2",
+    [
+        (1.0, 1),
+        (1.0, "one"),
+        # See https://github.com/dask/dask/issues/5968 and
+        # https://github.com/pandas-dev/pandas/issues/32934
+        pytest.param(1.0, pd.to_datetime("1970-01-01"), marks=pytest.mark.xfail),
+        (1, "one"),
+        (1, pd.to_datetime("1970-01-01")),
+        ("one", pd.to_datetime("1970-01-01")),
+    ],
+)
+def test_concat_different_dtypes(value_1, value_2):
     # check that the resulting dataframe has coherent dtypes
-    # refer to https://github.com/dask/dask/issues/4685
-    pdf1 = pd.DataFrame(
-        {"x": [1, 2, 3, 4, 6, 7], "y": list("abcdef")}, index=[1, 2, 3, 4, 6, 7]
-    )
-    ddf1 = dd.from_pandas(pdf1, 2)
-    pdf2 = pd.DataFrame(
-        {"x": [1.0, 2.0, 3.0, 4.0, 6.0, 7.0], "y": list("abcdef")},
-        index=[8, 9, 10, 11, 12, 13],
-    )
-    ddf2 = dd.from_pandas(pdf2, 2)
+    # refer to https://github.com/dask/dask/issues/4685 and
+    # https://github.com/dask/dask/issues/5968
+    df_1 = pd.DataFrame({"x": [value_1]})
+    df_2 = pd.DataFrame({"x": [value_2]})
+    df = pd.concat([df_1, df_2], axis=0)
 
-    expected = pd.concat([pdf1, pdf2], join=join)
-    result = dd.concat([ddf1, ddf2], join=join)
-    assert_eq(expected, result)
+    pandas_dtype = df["x"].dtype
 
-    dtypes_list = dask.compute([part.dtypes for part in result.to_delayed()])
-    assert len(set(map(str, dtypes_list))) == 1  # all the same
+    ddf_1 = dd.from_pandas(df_1, npartitions=1)
+    ddf_2 = dd.from_pandas(df_2, npartitions=1)
+    ddf = dd.concat([ddf_1, ddf_2], axis=0)
+
+    dask_dtypes = list(ddf.map_partitions(lambda x: x.dtypes).compute())
+
+    assert dask_dtypes == [pandas_dtype, pandas_dtype]
 
 
 @pytest.mark.parametrize("how", ["inner", "outer", "left", "right"])

--- a/dask/dataframe/tests/test_shuffle.py
+++ b/dask/dataframe/tests/test_shuffle.py
@@ -292,10 +292,12 @@ def test_rearrange_cleanup():
     assert len(os.listdir(tmpdir)) == 0
 
 
+def mock_shuffle_group_3(df, col, npartitions, p):
+    raise ValueError("Mock exception!")
+
+
 def test_rearrange_disk_cleanup_with_exception():
     # ensure temporary files are cleaned up when there's an internal exception.
-    def mock_shuffle_group_3(df, col, npartitions, p):
-        raise ValueError("Mock exception!")
 
     with mock.patch("dask.dataframe.shuffle.shuffle_group_3", new=mock_shuffle_group_3):
         df = pd.DataFrame({"x": np.random.random(10)})

--- a/dask/delayed.py
+++ b/dask/delayed.py
@@ -231,6 +231,15 @@ def delayed(obj, name=None, pure=None, nout=None, traverse=True):
         to hashing content. Note that this only affects the name of the object
         wrapped by this call to delayed, and *not* the output of delayed
         function calls - for that use ``dask_key_name=`` as described below.
+
+        .. note::
+
+           Because this ``name`` is used as the key in task graphs, you should
+           ensure that it uniquely identifies ``obj``. If you'd like to provide
+           a descriptive name that is still unique, combine the descriptive name
+           with :func:`dask.base.tokenize` of the ``array_like``. See
+           :ref:`graphs` for more.
+
     pure : bool, optional
         Indicates whether calling the resulting ``Delayed`` object is a pure
         operation. If True, arguments to the call are hashed to produce
@@ -338,11 +347,15 @@ def delayed(obj, name=None, pure=None, nout=None, traverse=True):
 
     The key name of a delayed object is hashed by default if ``pure=True`` or
     is generated randomly if ``pure=False`` (default).  To explicitly set the
-    name, you can use the ``name`` keyword:
+    name, you can use the ``name`` keyword. To ensure that the key is unique
+    you should include the tokenized value as well, or otherwise ensure that
+    it's unique:
 
-    >>> a = delayed([1, 2, 3], name='mylist')
-    >>> a
-    Delayed('mylist')
+    >>> from dask.base import tokenize
+    >>> data = [1, 2, 3]
+    >>> a = delayed(data, name='mylist-' + tokenize(data))
+    >>> a  # doctest: +SKIP
+    Delayed('mylist-55af65871cb378a4fa6de1660c3e8fb7')
 
     Delayed results act as a proxy to the underlying object. Many operators
     are supported:

--- a/dask/dot.py
+++ b/dask/dot.py
@@ -130,7 +130,7 @@ def to_graphviz(
     data_attributes=None,
     function_attributes=None,
     rankdir="BT",
-    graph_attr={},
+    graph_attr=None,
     node_attr=None,
     edge_attr=None,
     collapse_outputs=False,
@@ -141,6 +141,8 @@ def to_graphviz(
         data_attributes = {}
     if function_attributes is None:
         function_attributes = {}
+    if graph_attr is None:
+        graph_attr = {}
 
     graph_attr = graph_attr or {}
     graph_attr["rankdir"] = rankdir
@@ -158,7 +160,7 @@ def to_graphviz(
             func_name = name((k, "function")) if not collapse_outputs else k_name
             if collapse_outputs or func_name not in seen:
                 seen.add(func_name)
-                attrs = function_attributes.get(k, {})
+                attrs = function_attributes.get(k, {}).copy()
                 attrs.setdefault("label", key_split(k))
                 attrs.setdefault("shape", "circle")
                 g.node(func_name, **attrs)
@@ -171,7 +173,7 @@ def to_graphviz(
                 dep_name = name(dep)
                 if dep_name not in seen:
                     seen.add(dep_name)
-                    attrs = data_attributes.get(dep, {})
+                    attrs = data_attributes.get(dep, {}).copy()
                     attrs.setdefault("label", box_label(dep, verbose))
                     attrs.setdefault("shape", "box")
                     g.node(dep_name, **attrs)
@@ -187,7 +189,7 @@ def to_graphviz(
 
         if (not collapse_outputs or k_name in connected) and k_name not in seen:
             seen.add(k_name)
-            attrs = data_attributes.get(k, {})
+            attrs = data_attributes.get(k, {}).copy()
             attrs.setdefault("label", box_label(k, verbose))
             attrs.setdefault("shape", "box")
             g.node(k_name, **attrs)

--- a/dask/tests/test_dot.py
+++ b/dask/tests/test_dot.py
@@ -3,6 +3,7 @@ from functools import partial
 import re
 from operator import add, neg
 import sys
+import copy
 import pytest
 
 
@@ -271,3 +272,21 @@ def test_delayed_kwargs_apply():
     label = task_label(x.dask[x.key])
     assert "f" in label
     assert "apply" not in label
+
+
+def test_immutable_attributes():
+    def inc(x):
+        return x + 1
+
+    dsk = {"a": (inc, 1), "b": (inc, 2), "c": (add, "a", "b")}
+    attrs_func = {"a": {}}
+    attrs_data = {"b": {}}
+    attrs_func_test = copy.deepcopy(attrs_func)
+    attrs_data_test = copy.deepcopy(attrs_data)
+
+    to_graphviz(
+        dsk, function_attributes=attrs_func, data_attributes=attrs_data,
+    )
+
+    assert attrs_func_test == attrs_func
+    assert attrs_data_test == attrs_data

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,6 +1,47 @@
 Changelog
 =========
 
+2.13.0 / 2020-03-25
+-------------------
+
+Array
++++++
+
+- Support ``dtype`` and other keyword arguments in ``da.random`` (:pr:`6030`) `Matthew Rocklin`_
+- Register support for ``cupy`` sparse ``hstack``/``vstack`` (:pr:`5735`) `Corey J. Nolet`_
+- Force ``self.name`` to ``str`` in ``dask.array`` (:pr:`6002`) `Chuanzhu Xu`_
+
+Bag
++++
+
+- Set ``rename_fused_keys`` to ``None`` by default in ``bag.optimize`` (:pr:`6000`) `Lucas Rademaker`_
+
+Core
+++++
+
+- Copy dict in ``to_graphviz`` to prevent overwriting (:pr:`5996`) `JulianWgs`_
+- Stricter pandas ``xfail`` (:pr:`6024`) `Tom Augspurger`_
+- Fix CI failures (:pr:`6013`) `James Bourbeau`_
+- Update ``toolz`` to 0.8.2 and use ``tlz`` (:pr:`5997`) `Ryan Grout`_
+- Move Windows CI builds to GitHub Actions (:pr:`5862`) `James Bourbeau`_
+
+DataFrame
++++++++++
+
+- Improve path-related exceptions in ``read_hdf`` (:pr:`6032`) `psimaj`_
+- Fix ``dtype`` handling in ``dd.concat`` (:pr:`6006`) `mlondschien`_
+- Handle cudf's leftsemi and leftanti joins (:pr:`6025`) `Richard J Zamora`_
+- Remove unused ``npartitions`` variable in ``dd.from_pandas`` (:pr:`6019`) `Daniel Saxton`_
+- Added shuffle to ``DataFrame.random_split`` (:pr:`5980`) `petiop`_
+
+Documentation
++++++++++++++
+
+- Fix indentation in scheduler-overview docs (:pr:`6022`) `Matthew Rocklin`_
+- Update task graphs in optimize docs (:pr:`5928`) `Julia Signell`_
+- Optionally get rid of intermediary boxes in visualize, and add more labels (:pr:`5976`) `Julia Signell`_
+
+
 2.12.0 / 2020-03-06
 -------------------
 
@@ -2997,3 +3038,10 @@ Other
 .. _`Thomas J Fan`: https://github.com/thomasjpfan
 .. _`Henrik Andersson`: https://github.com/hnra
 .. _`James Lamb`: https://github.com/jameslamb
+.. _`Corey J. Nolet`: https://github.com/cjnolet
+.. _`Chuanzhu Xu`: https://github.com/xcz011
+.. _`Lucas Rademaker`: https://github.com/lr4d
+.. _`JulianWgs`: https://github.com/JulianWgs
+.. _`psimaj`: https://github.com/psimaj
+.. _`mlondschien`: https://github.com/mlondschien
+.. _`petiop`: https://github.com/petiop

--- a/docs/source/graphs.rst
+++ b/docs/source/graphs.rst
@@ -1,3 +1,5 @@
+.. _graphs:
+
 Task Graphs
 ===========
 

--- a/docs/source/scheduler-overview.rst
+++ b/docs/source/scheduler-overview.rst
@@ -4,10 +4,10 @@ Scheduler Overview
 After we create a dask graph, we use a scheduler to run it. Dask currently
 implements a few different schedulers:
 
-- ``dask.threaded.get``: a scheduler backed by a thread pool
-- ``dask.multiprocessing.get``: a scheduler backed by a process pool
-- ``dask.get``: a synchronous scheduler, good for debugging
-- ``distributed.Client.get``: a distributed scheduler for executing graphs
+-  ``dask.threaded.get``: a scheduler backed by a thread pool
+-  ``dask.multiprocessing.get``: a scheduler backed by a process pool
+-  ``dask.get``: a synchronous scheduler, good for debugging
+-  ``distributed.Client.get``: a distributed scheduler for executing graphs
    on multiple machines.  This lives in the external distributed_ project.
 
 .. _distributed: https://distributed.dask.org/en/latest/

--- a/iloc.md
+++ b/iloc.md
@@ -1,0 +1,148 @@
+# Designing a Dask DataFrame `.iloc` method
+Implementing distributed `.iloc` requires mapping between two "index spaces":
+- **idx** space:
+  - linear idxs into the overall DDF
+  - users pass these to `.iloc`
+- **part-idx** ("partition index") space:
+  - each row is associated with a `(block idx, intra-block idx)` tuple:
+    - `block idx` is the index of the containing block (a.k.a. "partition") in the DDF's array of blocks (each of which is a `pd.DataFrame`)
+    - `intra-block idx` is the index of the row within its block
+  - note that both spaces support positive- and negative-integer indices, in principle
+
+## Computing "part-idxs"
+Computing **part-idxs** from **idxs** can be expensive; you have to know all block sizes "to the left" (resp. "right") of positive (resp. negative) part-idxs.
+
+That typically requires `.compute()`ing some blocks, and then either:
+1. throwing them away
+  - when you needed to find a **part-idx** *from which to start returning elements*
+  - e.g. in response to a slice like `[1000:]`
+2. recomputing them from scratch once you've identified the **part-idxs** that are responsive to the given **idx**-range
+  - e.g. in response to a slice like `[:1000]`
+
+Each of these cases comes with a serious foot-gun:
+
+### 1. Find a block to start from, take blocks from there (e.g. `.iloc[1000:]`) <a id="compute-suffix"></a>
+Naively, a slice like `[1000:]` can be served by:
+- `compute`ing (really just getting the `len()` of) blocks from the start until you've seen 1000 elements (more detail on how to do this [below](#iterative-block-group-computing))
+- return a DDF that:
+  - does an appropriate `.iloc` inside the block containing **idx** 1000 (so that **idx** 1000 is the first row in the returned block, and new DDF)
+  - returns [that first `.iloc`'d/partial block] prepended to [all subsequent blocks (in full)]
+
+#### Difficulty: existence of Nearest Shuffle-Stage Ancestor (NSA)  <a id="nsa-difficulty"></a>
+Unfortunately, a dependency of the DDF being `.iloc`'d may be the result of an "all-to-all shuffle" (where each result block is potentially comprised of elements from any of the blocks on the input side; distributed sorts, group-by's, etc. generally have this property).
+
+This means that getting just the first block of the DDF (to check its `len`) can require *all partitions* of (some or all of) its dependency graph to be computed
+
+Additionally, if we find out that `[1000:]` is served by looking at blocks `[3:]`, any later `compute` that uses those `[3:]` blocks will again compute *all partitions* of some/all dependencies.
+
+#### Mitigation: `persist()` the NSA <a id="persist-nsa"></a>
+One solution is to find the nearest shuffle-stage ancestor and fully `compute` and [`.persist()`](https://distributed.dask.org/en/latest/memory.html#persisting-collections) it.
+
+##### Caveats: memory pressure, spilling? <a id="persist-nsa-caveats"></a>
+I'm not sure whether Dask spills to disk if `.persist`ing causes memory pressue:
+- If it does, an `.iloc` that relies on this optimization can potentially be quite expensive
+- If it doesn't, an `.iloc` is liable to OOM workers
+
+So, even the best possible implementation here will likely still have some subtle but occasionally serious "gotchas".
+
+### 2. Take all blocks up to a certain point (e.g. `.iloc[:1000]`) <a id="compute-prefix"></a>
+The main danger (and mitigations) here are basically the same as above:
+- Suppose you learn that **idx** `1000` is in block `3` (again, [see below for discussion about how](#iterative-block-group-computing))
+- Great! you can pass along a new DDF made of just blocks `[:3]` (this time with the *last* block `.iloc`'d/partial, instead of the *first*)
+- However, you still fully computed any upstream shuffle stages
+  - you'll probably want to find the [NSA](#nsa-difficultry), `.persist()` it, and hope for the best (as in [case 1. above](#persist-nsa-caveats))
+- Additionally, you probably computed all rows in blocks `[:3]` (to get the blocks' lengths), and then threw away the rows
+  - you should probably `persist` blocks `[:3]` as well
+    - but, if you persist blocks `[:3]`, do you still need to persist the full NSA?
+      - I believe the answer is "yes".
+      - The problem is how you learned that `3` blocks was enough to get the first `1000` rows.
+      - In general, you'd have to either have:
+        - computed all block sizes in the DDF being `.iloc`'d, or
+        - embarked on an [iterative-widening "try computing the first K blocks and seeing how many elements that fetches" approach](#iterative-block-group-computing), which warrants `persist`ing any nearest shuffle ancestor (NSA)
+    - so, you'll want to `persist` both the NSA as well as the blocks that contain the **idxs** you seek. 
+
+### `len`-only pipeline mode?
+There may be situations where it's easy+cheap to run the whole graph upstream of a DDF *while only computing the partition sizes at each stage*.
+
+Can a final per-block `len()` be "pushed-down" so that a DDF could compute all its block-sizes (either at graph-construction time or `.iloc`-execution time), allowing arbitrary `.iloc`'ing and filtering of blocks to construct the result DDF?
+
+Some examples where this optimization would be possible: 
+- A DDF is loaded from blocks read from an HDF5 `Dataset`
+- A DDF's blocks are constructed from a Dask Array of known chunk sizes 
+
+In both cases, each DDF block's length will be known at graph-construction time.
+
+If the next Dask op on such a DDF merely slices out some columns, that DDF still knows its block-sizes, and can be trivially `.iloc`'d. Block-`len`s can be propagated through some complex graphs without `.compute()`ing anything.
+
+### Example Slices, required part-idxs <a id="part-idx-table"></a>
+
+Here are a bunch of slices, and which "positive" (`pos`) and "negative" (`neg`) **idxs** we must compute **part-idxs** for in order to serve an `.iloc` of that slice:
+<table>
+  <tbody>
+  <tr>
+    <th colspan="2" rowspan="3"></th>
+    <th colspan="9"><code>end</code></th>
+  </tr>
+  <tr>
+    <th colspan="3"><code>+</code></th>
+    <th colspan="3"><code>-</code></th>
+    <th colspan="3"><code>:</code></th>
+  </tr>
+  <tr>
+    <th>slice</th><th>pos</th><th>neg</th>
+    <th>slice</th><th>pos</th><th>neg</th>
+    <th>slice</th><th>pos</th><th>neg</th>
+  </tr>
+  <tr>
+    <td rowspan="3"><b><code>start</code></b></td>
+    <td><code><b>+</b></code></td>
+    <td><code>[&nbsp;&nbsp;5:10]</code></td><td><code>10</code></td><td></td>
+    <td><code>[&nbsp;10:&nbsp;-5]</code></td><td><code>10</code></td><td><code>-5</code></td>
+    <td><code>[&nbsp;10:&nbsp;&nbsp;]</code></td><td><code>10</code></td><td></td>
+  </tr>
+  <tr>
+    <td><code><b>-</b></code></td>
+    <td><code>[-10:10]</code></td><td><code>10</code></td><td><code>-10</code></td>
+    <td><code>[-10:&nbsp;-5]</code></td><td></td><td><code>-10</code></td>
+    <td><code>[-10:&nbsp;&nbsp;]</code></td><td></td><td><code>-10</code></td>
+  </tr>
+  <tr>
+    <td><code><b>:</b></code></td>
+    <td><code>[&nbsp;&nbsp;&nbsp;:10]</code></td><td><code>10</code></td><td></td>
+    <td><code>[&nbsp;&nbsp;&nbsp;:-10]</code></td><td></td><td><code>-10</code></td>
+    <td><code>[&nbsp;&nbsp;&nbsp;:&nbsp;&nbsp;]</code></td><td></td><td></td>
+  </tr>
+  </tbody>
+</table>
+
+### Fetching groups of blocks *forward from the first block* or *backward from the last block* <a id="iterative-block-group-computing"></a>
+All slices above require finding zero or one positive **part-idxs** and zero or one negative **part-idxs**.
+
+Here's an algorithm for computing a **part-idx** starting from either end:
+
+1. `.compute()` the first $N$ blocks from the appropriate end
+  - $N=5$ can be our own hard-coded default / initial value
+  - maybe there's a global to change it if you want
+2. If those blocks contain the end of the **idx** we are seeking, we're done
+  - some further partial-filtering of the block containing the **idx** should be handled separately
+3. Otherwise:
+  - Estimate avg records/block based on all blocks computed so far
+  - Figure out how many more blocks are likely required to cover desired **idx** (and throw in some padding)
+  - Go back to step 1. but with new $N$
+
+I suspect the number of successive `compute()`s (repetitions of step 1.) will have a mode of 1 (and average of like, 1.2?). It should perform reasonably well and not be too wasteful, in most cases.
+
+#### `raise` on slices that waste too many rows?
+
+One possible "gotcha" we might like to protect against by default:
+
+What if a user asks for `ddf.iloc[1e8:(1e8+10)]` (assume the DF is still bigger, like `1e9` rows, so we know we should treat the slice as a "prefix")?
+
+Should we `compute` the first `1e8+10` rows just to serve them 10 rows?
+
+If the user expects random access to those 10 rows, maybe it's correct to `raise`, because it's too dangerous to risk surprising them with such a huge computation. Maybe that's part of why Dask does `raise`s today.
+
+##### Configurable "wasted rows" threshold
+I can imagine picking a number, say 99%, and `raise`ing if the user requests a slice that will be >99% wasted rows. You can do `df.iloc[1e8:2e8]` but not `df.iloc[1e8:(1e8+1e4)]`, and the threshold can be a global/env/config var.
+
+Building guardrails here may also not be necessary / worthwhile.


### PR DESCRIPTION
This allows `__len__` calls to shortcut through `_len` when it is set to a value.

We have more advanced things coming, I know.  Right now it allows the native AnnData constructor to run on daskified `obs` and `var` w/o modifications b/c this will no longer quietly trigger a full `.compute()`!
