### PR TITLE
Daskified index with dask arrays.

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -1511,6 +1511,12 @@ class Array(DaskMethodsMixin):
             )
 
     def __getitem__(self, index):
+        if is_dask_collection(index):
+            # NOTE: This will resolve the index and then use it.
+            # Ideally, if the index is partitioned like this array,
+            # we could apply each partition in the index to each partition in self. -ssmith
+            return self.map_blocks(operator.getitem, index, dtype=self.dtype)
+
         # Field access, e.g. x['a'] or x[['a', 'b']]
         if isinstance(index, str) or (
             isinstance(index, list) and index and all(isinstance(i, str) for i in index)

--- a/dask/array/slicing.py
+++ b/dask/array/slicing.py
@@ -891,11 +891,14 @@ def check_index(ind, dimension):
     elif ind is None:
         return
 
-    elif ind >= dimension:
+    import pandas as pd
+    if isinstance(ind, pd.Series):
+        ind = ind.shape[0] - 1
+
+    if ind >= dimension:
         raise IndexError(
             "Index is not smaller than dimension %d >= %d" % (ind, dimension)
         )
-
     elif ind < -dimension:
         msg = "Negative index is not greater than negative dimension %d <= -%d"
         raise IndexError(msg % (ind, dimension))


### PR DESCRIPTION
### What this changes:

- [x] A dask series can be used in array slicing
- [x] A naive update to dask arrays `__getitem__` that works in the non-partitioned case.

Next change will include the partitioned case.