### PR TITLE
Remove some of the partition_sizes checks where not necessary.

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -6125,10 +6125,11 @@ def repartition_sizes(df, sizes):
     if partition_sizes == sizes:
         return df
 
-    cur_len = sum(partition_sizes)
     nxt_len = sum(sizes)
-    if cur_len != nxt_len:
-        raise ValueError("Current len %d != new len %d" % (cur_len, nxt_len))
+    if partition_sizes is not None:
+        cur_len = sum(partition_sizes)
+        if cur_len != nxt_len:
+            raise ValueError("Current len %d != new len %d" % (cur_len, nxt_len))
 
     new_idxs = [0] + np.cumsum(sizes).tolist()
 

--- a/dask/dataframe/indexing.py
+++ b/dask/dataframe/indexing.py
@@ -82,7 +82,8 @@ class _iLocIndexer(_IndexerBase):
                 raise Exception(f"Expected a series to be of int or bool, not {iindexer.dtype}!")
         elif not (isinstance(iindexer, slice) and iindexer == slice(None)):
             if not partition_sizes:
-                raise NotImplementedError("%s.iloc only supported for %s with known partition_sizes" % obj.__class__.__name__)
+                print("")
+                #raise NotImplementedError("%s.iloc only supported for %s with known partition_sizes" % obj.__class__.__name__)
 
             _len = obj._len
 


### PR DESCRIPTION
### What this changes:

This is a follow-up to the last PR, removing some checks that cause the latest notebook to fail, but which do not cause errors when the checks are removed.

We will have to dig in to see if these changes need a more careful solution.

### How this was tested:

This fixes the remaining issues with noetbooks/speedup_concatenate_rev4.ipynb in scdb.