### PR TITLE
iloc/slicing improvements

### DIFF
--- a/dask/array/backends.py
+++ b/dask/array/backends.py
@@ -74,6 +74,8 @@ def register_scipy_sparse():
 
 
 import numpy as np
+
+
 def numpy_matrix_concatenate(L, axis=0):
     if axis == 0:
         return np.vstack(L)
@@ -81,9 +83,9 @@ def numpy_matrix_concatenate(L, axis=0):
         return np.hstack(L)
     else:
         msg = (
-            "Can only concatenate numpy matrices for axis in "
-            "{0, 1}.  Got %s" % axis
+            "Can only concatenate numpy matrices for axis in " "{0, 1}.  Got %s" % axis
         )
         raise ValueError(msg)
+
 
 concatenate_lookup.register(np.matrix, numpy_matrix_concatenate)

--- a/dask/array/reductions.py
+++ b/dask/array/reductions.py
@@ -290,6 +290,7 @@ def partial_reduce(
     # operations like `sum`, and so effectively have keepdims=True when axis=0 or axis=1.
     try:
         import numpy as np
+
         if isinstance(reduced_meta, np.matrix) and len(split_every) == 1:
             keepdims = True
     except ImportError:
@@ -297,6 +298,7 @@ def partial_reduce(
 
     try:
         from scipy.sparse import spmatrix
+
         if isinstance(reduced_meta, spmatrix) and len(split_every) == 1:
             keepdims = True
     except ImportError:

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -4621,7 +4621,8 @@ def test_scipy_sparse_sum(fmt, axis, keepdims):
     spmat_sum = spmat.sum(axis=axis)
     if axis == 0:
         pytest.xfail(
-            "TODO: default to keepdims=True behavior at the dask level when _meta is spmatrix and first dimension is being summed over"
+            "TODO: default to keepdims=True behavior at the dask level when _meta is spmatrix and first dimension is "
+            "being summed over"
         )
     else:
         assert_almost_equal(dask_sum, spmat_sum)

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -3293,7 +3293,7 @@ def test_A_property():
 
 @pytest.mark.filterwarnings("ignore:the matrix subclass:PendingDeprecationWarning")
 def test_A_property_matrix():
-    x = da.ones((5,5), chunks=(2,2))
+    x = da.ones((5, 5), chunks=(2, 2))
     assert x.A is x
 
     from numpy import array, float64, matrix, ndarray
@@ -3301,36 +3301,38 @@ def test_A_property_matrix():
     y = x.map_blocks(matrix)
     assert type(y._meta) is matrix
     from numpy.testing import assert_array_equal
-    assert_array_equal(y._meta, matrix([], dtype=float64).reshape(0,0))
+
+    assert_array_equal(y._meta, matrix([], dtype=float64).reshape(0, 0))
 
     A = y.A
     assert A is not y
     assert_eq(A.compute(), y.compute())
     assert type(A._meta) is ndarray
-    assert_array_equal(A._meta, array([], dtype=float64).reshape((0,0)))
+    assert_array_equal(A._meta, array([], dtype=float64).reshape((0, 0)))
 
 
-@pytest.mark.parametrize("spmatrix", ['csr','csc','coo'])
+@pytest.mark.parametrize("spmatrix", ["csr", "csc", "coo"])
 @pytest.mark.filterwarnings("ignore:the matrix subclass:PendingDeprecationWarning")
 def test_A_property_spmatrix(spmatrix):
     pytest.importorskip("scipy.sparse")
 
-    x = da.ones((5,5), chunks=(2,2))
+    x = da.ones((5, 5), chunks=(2, 2))
     assert x.A is x
 
     from numpy import array, float64, ndarray
 
     from scipy.sparse import csr_matrix, csc_matrix, coo_matrix
+
     mat_map = {
-        'csr': csr_matrix,
-        'csc': csc_matrix,
-        'coo': coo_matrix,
+        "csr": csr_matrix,
+        "csc": csc_matrix,
+        "coo": coo_matrix,
     }
     mat = mat_map[spmatrix]
 
     y = x.map_blocks(mat)
     assert type(y._meta) is mat
-    empty = mat([], dtype=float64).reshape(0,0)
+    empty = mat([], dtype=float64).reshape(0, 0)
     assert (y._meta != empty).nnz == 0
 
     A = y.A
@@ -3339,8 +3341,8 @@ def test_A_property_spmatrix(spmatrix):
     assert type(A._meta) is ndarray
 
     from numpy.testing import assert_array_equal
-    assert_array_equal(A._meta, array([], dtype=float64).reshape((0,0)))
 
+    assert_array_equal(A._meta, array([], dtype=float64).reshape((0, 0)))
 
 
 def test_copy_mutate():
@@ -4224,6 +4226,7 @@ def test_dask_array_holds_numpy_matrix_containers():
 
     assert isinstance(yy, np.matrix)
     from numpy.testing import assert_array_equal
+
     assert_array_equal(yy, xx)
 
     z = x.T.map_blocks(np.matrix)
@@ -4256,7 +4259,9 @@ def test_dask_array_holds_scipy_sparse_containers():
     assert (zz == xx.T).all()
 
 
-@pytest.mark.parametrize("axis,stack,spmatrix", [(0, 'vstack', 'csr'), (1, 'hstack', 'coo')])
+@pytest.mark.parametrize(
+    "axis,stack,spmatrix", [(0, "vstack", "csr"), (1, "hstack", "coo")]
+)
 def test_scipy_sparse_concatenate(axis, stack, spmatrix):
     pytest.importorskip("scipy.sparse")
     import scipy.sparse
@@ -4274,14 +4279,14 @@ def test_scipy_sparse_concatenate(axis, stack, spmatrix):
     z = da.concatenate(ys, axis=axis)
     zz = z.compute()
 
-    if spmatrix == 'coo':
+    if spmatrix == "coo":
         spmatrix = scipy.sparse.coo_matrix
     else:
         spmatrix = scipy.sparse.csr_matrix
 
     assert isinstance(zz, spmatrix)
 
-    if stack == 'vstack':
+    if stack == "vstack":
         sp_concatenate = scipy.sparse.vstack
     else:
         sp_concatenate = scipy.sparse.hstack
@@ -4555,32 +4560,55 @@ def test_rechunk_auto():
     assert y.npartitions == 1
 
 
-@pytest.mark.parametrize("fmt", ['csr','csc','coo',])
-@pytest.mark.parametrize("axis", [0, 1, None,])
-@pytest.mark.parametrize("keepdims", [None, False, True,])
+@pytest.mark.parametrize(
+    "fmt",
+    [
+        "csr",
+        "csc",
+        "coo",
+    ],
+)
+@pytest.mark.parametrize(
+    "axis",
+    [
+        0,
+        1,
+        None,
+    ],
+)
+@pytest.mark.parametrize(
+    "keepdims",
+    [
+        None,
+        False,
+        True,
+    ],
+)
 def test_scipy_sparse_sum(fmt, axis, keepdims):
     pytest.importorskip("scipy.sparse")
     from scipy.sparse import coo_matrix, csc_matrix, csr_matrix, random
 
     fmt_map = {
-        'coo': coo_matrix,
-        'csc': csc_matrix,
-        'csr': csr_matrix,
+        "coo": coo_matrix,
+        "csc": csc_matrix,
+        "csr": csr_matrix,
     }
     fmt_cls = fmt_map[fmt]
 
     M, N = 100, 100
-    m, n =  20,  10
-    if fmt == 'coo':
-        spmat = random(M, N, format='csr')
-        x = da.from_array(spmat, chunks=(m,n), asarray=False).map_blocks(coo_matrix)
+    m, n = 20, 10
+    if fmt == "coo":
+        spmat = random(M, N, format="csr")
+        x = da.from_array(spmat, chunks=(m, n), asarray=False).map_blocks(coo_matrix)
     else:
         spmat = random(M, N, format=fmt)
         assert isinstance(spmat, fmt_cls)
-        x = da.from_array(spmat, chunks=(m,n), asarray=False)
+        x = da.from_array(spmat, chunks=(m, n), asarray=False)
 
-    block_typenames = x.map_blocks(lambda c: np.array([[type(c).__name__]]), dtype=object).compute()
-    expected = np.full(((M+m-1)//m, (N+n-1)//n), '%s_matrix' % fmt)
+    block_typenames = x.map_blocks(
+        lambda c: np.array([[type(c).__name__]]), dtype=object
+    ).compute()
+    expected = np.full(((M + m - 1) // m, (N + n - 1) // n), "%s_matrix" % fmt)
     assert_eq(block_typenames, expected)
 
     xx = x.compute()
@@ -4592,6 +4620,8 @@ def test_scipy_sparse_sum(fmt, axis, keepdims):
     dask_sum = x.sum(axis=axis).compute()
     spmat_sum = spmat.sum(axis=axis)
     if axis == 0:
-        pytest.xfail("TODO: default to keepdims=True behavior at the dask level when _meta is spmatrix and first dimension is being summed over")
+        pytest.xfail(
+            "TODO: default to keepdims=True behavior at the dask level when _meta is spmatrix and first dimension is being summed over"
+        )
     else:
         assert_almost_equal(dask_sum, spmat_sum)

--- a/dask/array/tests/test_rechunk.py
+++ b/dask/array/tests/test_rechunk.py
@@ -535,8 +535,8 @@ def test_rechunk_unknown_from_array():
     dd = pytest.importorskip("dask.dataframe")
     x = dd.from_array(da.ones(shape=(4, 4), chunks=(2, 2))).values
     result = x.rechunk((None, 4))
-    assert x.chunks == ((2,2),(4,))
-    assert result.chunks == ((2,2),(4,))
+    assert x.chunks == ((2, 2), (4,))
+    assert result.chunks == ((2, 2), (4,))
     assert_eq(x, result)
 
 

--- a/dask/array/utils.py
+++ b/dask/array/utils.py
@@ -66,7 +66,9 @@ def meta_from_array(x, ndim=None, dtype=None):
         not hasattr(x, "shape")
         or not hasattr(x, "dtype")
         or not isinstance(x.shape, tuple)
-        or not hasattr(x, '__getitem__')  # scipy.sparse.coo_matrix doesn't implement slicing, but is a suitable _meta value
+        or not hasattr(
+            x, "__getitem__"
+        )  # scipy.sparse.coo_matrix doesn't implement slicing, but is a suitable _meta value
     ):
         return x
 

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -378,10 +378,10 @@ class _Frame(DaskMethodsMixin, OperatorMethodMixin):
     @property
     def partition_idx_ranges(self):
         if self.partition_sizes:
-            partition_ends = np.cumsum(self.partition_sizes).tolist()
+            partition_ends = [0] + np.cumsum(self.partition_sizes).tolist()
             return zip(
-                [0] + partition_ends[:-1],
                 partition_ends,
+                partition_ends[1:],
             )
         else:
             return None
@@ -1251,6 +1251,124 @@ Dask Name: {name}, {task} tasks"""
         A Dask DataFrame
         """
         return IndexCallable(self._partitions)
+
+    def __getitem__(self, key):
+        name = "getitem-%s" % tokenize(self, key)
+        if np.isscalar(key) or isinstance(key, (tuple, str)):
+
+            if isinstance(self._meta.index, (pd.DatetimeIndex, pd.PeriodIndex)):
+                if key not in self._meta.columns:
+                    return self.loc[key]
+
+            # error is raised from pandas
+            meta = self._meta[_extract_meta(key)]
+            dsk = partitionwise_graph(operator.getitem, name, self, key)
+            graph = HighLevelGraph.from_collections(name, dsk, dependencies=[self])
+            return new_dd_object(
+                graph, name, meta, self.divisions, self.partition_sizes
+            )
+
+        elif isinstance(key, slice):
+            from pandas.api.types import is_float_dtype
+
+            is_integer_slice = any(
+                isinstance(i, Integral) for i in (key.start, key.step, key.stop)
+            )
+            # Slicing with integer labels is always iloc based except for a
+            # float indexer for some reason
+            if is_integer_slice and not is_float_dtype(self.index.dtype):
+                # NOTE: this always fails currently, as iloc is mostly
+                # unsupported, but we call it anyway here for future-proofing
+                # and error-attribution purposes
+                return self.iloc[key]
+            else:
+                return self.loc[key]
+
+        if isinstance(key, (np.ndarray, list)) or (
+            not is_dask_collection(key) and (is_series_like(key) or is_index_like(key))
+        ):
+            # error is raised from pandas
+            meta = self._meta[_extract_meta(key)]
+
+            dsk = partitionwise_graph(operator.getitem, name, self, key)
+            graph = HighLevelGraph.from_collections(name, dsk, dependencies=[self])
+
+            if self.partition_sizes:
+                if isinstance(key, list):
+                    key = np.array(key)
+
+                dtype = key.dtype
+                if dtype == np.dtype("bool"):
+                    partition_ends = np.cumsum(self.partition_sizes)
+                    assert len(key) == partition_ends[-1]
+                    partition_starts = [0] + list(partition_ends[:-1])
+                    partition_sizes = []
+                    partition_keys = []
+                    for start, end in zip(partition_starts, partition_ends):
+                        keys = key[start:end]
+                        partition_keys.append(keys)
+                        size = np.sum(keys)
+                        partition_sizes.append(size)
+
+                    dsk = {
+                        (name, i): (
+                            operator.getitem,
+                            (self._name, i),
+                            partition_keys[i],
+                        )
+                        for i in range(self.npartitions)
+                    }
+                    graph = HighLevelGraph.from_collections(
+                        name, dsk, dependencies=[self]
+                    )
+                    return new_dd_object(
+                        graph, name, meta, self.divisions, partition_sizes
+                    )
+
+            return new_dd_object(
+                graph, name, meta, self.divisions, self.partition_sizes
+            )
+
+        if isinstance(key, Series):
+            return map_partitions(operator.getitem, self, key, meta=self._meta)
+
+        if isinstance(key, Array):
+            shape = key.shape
+            if len(shape) != 1:
+                raise NotImplementedError("Can only slice with Arrays of rank 1 (selecting rows)")
+            M = shape[0]
+
+            if self.partition_sizes is None:
+                raise RuntimeError("%s needs to know its partition_sizes in order to slice with an Array" % (type(self)))
+            partition_sizes = self.partition_sizes
+
+            if key.dtype == np.dtype(bool):
+                if M != len(self):
+                    raise RuntimeError("Mismatched sizes: %d-row %s vs. %d-row %s" % (len(self), type(self), M, type(key)))
+                chunks = key.chunks[0]
+                if not np.all([ isinstance(dim, int) for dim in chunks ]):
+                    raise NotImplementedError("Can't index into %s with Array with unknown chunks: %s" % (type(self), str(chunks)))
+
+                aligned_key = key.rechunk(partition_sizes)
+                akn = aligned_key._name
+                dsk = {
+                    (name, i): (
+                        operator.getitem,
+                        (self._name, i),
+                        (akn, i),
+                    )
+                    for i in range(self.npartitions)
+                }
+                graph = HighLevelGraph.from_collections(
+                    name, dsk, dependencies=[self, aligned_key]
+                )
+                return new_dd_object(
+                    graph, name, self._meta, self.divisions, partition_sizes,
+                )
+            elif key.dtype == np.dtype(int):
+                raise NotImplementedError("TODO: implement slicing %s's with Arrays of ints" % type(self))
+
+        raise NotImplementedError(key)
 
     # Note: iloc is implemented only on DataFrame
 
@@ -3160,14 +3278,15 @@ Dask Name: {name}, {task} tasks""".format(
 
         return partition_quantiles(self, npartitions, upsample=upsample)
 
-    def __getitem__(self, key):
-        if isinstance(key, Series):
-            return map_partitions(operator.getitem, self, key, meta=self._meta)
-
-        raise NotImplementedError(
-            "Series getitem in only supported for other series objects "
-            "with matching partition structure"
-        )
+    # def __getitem__(self, key):
+    #     if isinstance(key, Series):
+    #         return map_partitions(operator.getitem, self, key, meta=self._meta)
+    #     elif self.partition_sizes and isinstance(key, (slice, list)):
+    #         pass
+    #     raise NotImplementedError(
+    #         "Series getitem in only supported for other series objects "
+    #         "with matching partition structure"
+    #     )
 
     @derived_from(pd.DataFrame)
     def _get_numeric_data(self, how="any", subset=None):
@@ -3816,88 +3935,6 @@ class DataFrame(_Frame):
             "Depending on which of these results you need, use either "
             "`len(df.index) == 0` or `len(df.columns) == 0`"
         )
-
-    def __getitem__(self, key):
-        name = "getitem-%s" % tokenize(self, key)
-        if np.isscalar(key) or isinstance(key, (tuple, str)):
-
-            if isinstance(self._meta.index, (pd.DatetimeIndex, pd.PeriodIndex)):
-                if key not in self._meta.columns:
-                    return self.loc[key]
-
-            # error is raised from pandas
-            meta = self._meta[_extract_meta(key)]
-            dsk = partitionwise_graph(operator.getitem, name, self, key)
-            graph = HighLevelGraph.from_collections(name, dsk, dependencies=[self])
-            return new_dd_object(
-                graph, name, meta, self.divisions, self.partition_sizes
-            )
-
-        elif isinstance(key, slice):
-            from pandas.api.types import is_float_dtype
-
-            is_integer_slice = any(
-                isinstance(i, Integral) for i in (key.start, key.step, key.stop)
-            )
-            # Slicing with integer labels is always iloc based except for a
-            # float indexer for some reason
-            if is_integer_slice and not is_float_dtype(self.index.dtype):
-                # NOTE: this always fails currently, as iloc is mostly
-                # unsupported, but we call it anyway here for future-proofing
-                # and error-attribution purposes
-                return self.iloc[key]
-            else:
-                return self.loc[key]
-
-        if isinstance(key, (np.ndarray, list)) or (
-            not is_dask_collection(key) and (is_series_like(key) or is_index_like(key))
-        ):
-            # error is raised from pandas
-            meta = self._meta[_extract_meta(key)]
-
-            dsk = partitionwise_graph(operator.getitem, name, self, key)
-            graph = HighLevelGraph.from_collections(name, dsk, dependencies=[self])
-
-            if self.partition_sizes:
-                if isinstance(key, list):
-                    key = np.array(key)
-
-                dtype = key.dtype
-                if dtype == np.dtype("bool"):
-                    partition_ends = np.cumsum(self.partition_sizes)
-                    assert len(key) == partition_ends[-1]
-                    partition_starts = [0] + list(partition_ends[:-1])
-                    partition_sizes = []
-                    partition_keys = []
-                    for start, end in zip(partition_starts, partition_ends):
-                        keys = key[start:end]
-                        partition_keys.append(keys)
-                        size = np.sum(keys)
-                        partition_sizes.append(size)
-
-                    dsk = {
-                        (name, i): (
-                            operator.getitem,
-                            (self._name, i),
-                            partition_keys[i],
-                        )
-                        for i in range(self.npartitions)
-                    }
-                    graph = HighLevelGraph.from_collections(
-                        name, dsk, dependencies=[self]
-                    )
-                    return new_dd_object(
-                        graph, name, meta, self.divisions, partition_sizes
-                    )
-
-            return new_dd_object(
-                graph, name, meta, self.divisions, self.partition_sizes
-            )
-
-        if isinstance(key, Series):
-            return map_partitions(operator.getitem, self, key, meta=self._meta)
-
-        raise NotImplementedError(key)
 
     def __setitem__(self, key, value):
         if isinstance(key, (tuple, list)) and isinstance(value, DataFrame):

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -1330,7 +1330,18 @@ Dask Name: {name}, {task} tasks"""
             )
 
         if isinstance(key, Series):
-            return map_partitions(operator.getitem, self, key, meta=self._meta)
+            # do not perform dummy calculation, as columns will not be changed.
+            #
+            if self.divisions != key.divisions:
+                from .multi import _maybe_align_partitions
+
+                self, key = _maybe_align_partitions([self, key])
+            dsk = partitionwise_graph(operator.getitem, name, self, key)
+            graph = HighLevelGraph.from_collections(name, dsk, dependencies=[self, key])
+            return new_dd_object(graph, name, self, self.divisions)
+
+        if isinstance(key, DataFrame):
+            return self.where(key, np.nan)
 
         if isinstance(key, Array):
             shape = key.shape
@@ -1369,8 +1380,6 @@ Dask Name: {name}, {task} tasks"""
                 raise NotImplementedError("TODO: implement slicing %s's with Arrays of ints" % type(self))
 
         raise NotImplementedError(key)
-
-    # Note: iloc is implemented only on DataFrame
 
     def repartition(
         self,
@@ -3277,16 +3286,6 @@ Dask Name: {name}, {task} tasks""".format(
         from .partitionquantiles import partition_quantiles
 
         return partition_quantiles(self, npartitions, upsample=upsample)
-
-    # def __getitem__(self, key):
-    #     if isinstance(key, Series):
-    #         return map_partitions(operator.getitem, self, key, meta=self._meta)
-    #     elif self.partition_sizes and isinstance(key, (slice, list)):
-    #         pass
-    #     raise NotImplementedError(
-    #         "Series getitem in only supported for other series objects "
-    #         "with matching partition structure"
-    #     )
 
     @derived_from(pd.DataFrame)
     def _get_numeric_data(self, how="any", subset=None):

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -1346,19 +1346,30 @@ Dask Name: {name}, {task} tasks"""
         if isinstance(key, Array):
             shape = key.shape
             if len(shape) != 1:
-                raise NotImplementedError("Can only slice with Arrays of rank 1 (selecting rows)")
+                raise NotImplementedError(
+                    "Can only slice with Arrays of rank 1 (selecting rows)"
+                )
             M = shape[0]
 
             if self.partition_sizes is None:
-                raise RuntimeError("%s needs to know its partition_sizes in order to slice with an Array" % (type(self)))
+                raise RuntimeError(
+                    "%s needs to know its partition_sizes in order to slice with an Array"
+                    % (type(self))
+                )
             partition_sizes = self.partition_sizes
 
             if key.dtype == np.dtype(bool):
                 if M != len(self):
-                    raise RuntimeError("Mismatched sizes: %d-row %s vs. %d-row %s" % (len(self), type(self), M, type(key)))
+                    raise RuntimeError(
+                        "Mismatched sizes: %d-row %s vs. %d-row %s"
+                        % (len(self), type(self), M, type(key))
+                    )
                 chunks = key.chunks[0]
-                if not np.all([ isinstance(dim, int) for dim in chunks ]):
-                    raise NotImplementedError("Can't index into %s with Array with unknown chunks: %s" % (type(self), str(chunks)))
+                if not np.all([isinstance(dim, int) for dim in chunks]):
+                    raise NotImplementedError(
+                        "Can't index into %s with Array with unknown chunks: %s"
+                        % (type(self), str(chunks))
+                    )
 
                 aligned_key = key.rechunk(partition_sizes)
                 akn = aligned_key._name
@@ -1374,10 +1385,16 @@ Dask Name: {name}, {task} tasks"""
                     name, dsk, dependencies=[self, aligned_key]
                 )
                 return new_dd_object(
-                    graph, name, self._meta, self.divisions, partition_sizes,
+                    graph,
+                    name,
+                    self._meta,
+                    self.divisions,
+                    partition_sizes,
                 )
             elif key.dtype == np.dtype(int):
-                raise NotImplementedError("TODO: implement slicing %s's with Arrays of ints" % type(self))
+                raise NotImplementedError(
+                    "TODO: implement slicing %s's with Arrays of ints" % type(self)
+                )
 
         raise NotImplementedError(key)
 
@@ -4204,13 +4221,18 @@ class DataFrame(_Frame):
 
             if isinstance(v, Array):
                 from .io import series_from_dask_array
+
                 kwargs[k] = series_from_dask_array(v, index=self.index)
             elif isinstance(v, np.ndarray):
                 if not self.partition_sizes:
-                    ValueError("Can't assign a numpy array to a DataFrame without knowing the latter's partition_sizes")
+                    ValueError(
+                        "Can't assign a numpy array to a DataFrame without knowing the latter's partition_sizes"
+                    )
                 from dask.array import from_array
+
                 darr = from_array(v, chunks=(self.partition_sizes,))
                 from .io import series_from_dask_array
+
                 kwargs[k] = series_from_dask_array(darr, index=self.index)
 
         pairs = list(sum(kwargs.items(), ()))

--- a/dask/dataframe/indexing.py
+++ b/dask/dataframe/indexing.py
@@ -161,7 +161,8 @@ class _iLocIndexer(_IndexerBase):
                             stop += _len
                         else:
                             if stop < -1 and step < 0:
-                                # these will both end up empty if step is positive, otherwise this partitions the non-negative indices from the negatives
+                                # these will both end up empty if step is positive, otherwise this partitions the
+                                # non-negative indices from the negatives
                                 positives = obj.iloc[range(start, -1, step)]
                                 first_negative_idx = start % abs(step) + step
                                 negatives = obj.iloc[

--- a/dask/dataframe/indexing.py
+++ b/dask/dataframe/indexing.py
@@ -191,6 +191,9 @@ class _iLocIndexer(_IndexerBase):
 
                         return typ(start, stop, step), (stop - start) // step
 
+                    max_idx = start if start > stop else stop - step
+                    if max_idx >= _len:
+                        raise IndexError("Out of bounds: %d >= %d (key %s)" % (max_idx, _len, str(key)))
                     partition_slices = [
                         intersect(lo, hi, start, stop, step)
                         for lo, hi in partition_idx_ranges
@@ -238,7 +241,6 @@ class _iLocIndexer(_IndexerBase):
                         (name, 0): obj._meta
                     }
 
-                # dsk = {(name, idx): key for idx, key in enumerate(keys)}
                 meta = obj._meta
                 graph = HighLevelGraph.from_collections(
                     name, dsk, dependencies=[obj]

--- a/dask/dataframe/io/io.py
+++ b/dask/dataframe/io/io.py
@@ -453,6 +453,11 @@ def from_dask_array(x, columns=None, index=None, meta=None):
     if index is not None:
         if not isinstance(index, Index):
             raise ValueError("'index' must be an instance of dask.dataframe.Index")
+        partition_sizes = index.partition_sizes
+        if partition_sizes:
+            chunks = x.chunks[0]
+            if partition_sizes != chunks:
+                x = x.rechunk({0: partition_sizes})
         if index.npartitions != x.numblocks[0]:
             msg = (
                 "The index and array have different numbers of blocks. "

--- a/dask/dataframe/io/io.py
+++ b/dask/dataframe/io/io.py
@@ -11,7 +11,14 @@ from ...base import tokenize
 from ... import array as da
 from ...delayed import delayed
 
-from ..core import DataFrame, Series, Index, new_dd_object, has_parallel_type, HighLevelGraph
+from ..core import (
+    DataFrame,
+    Series,
+    Index,
+    new_dd_object,
+    has_parallel_type,
+    HighLevelGraph,
+)
 from ..shuffle import set_partition
 from ..utils import insert_meta_param_description, check_meta, make_meta, is_series_like
 
@@ -493,7 +500,9 @@ def from_dask_array(x, columns=None, index=None, meta=None):
             dsk[name, i] = (type(meta), chunk, ind, meta.columns)
 
     to_merge.extend([ensure_dict(x.dask), dsk])
-    return new_dd_object(merge(*to_merge), name, meta, divisions, partition_sizes=partition_sizes)
+    return new_dd_object(
+        merge(*to_merge), name, meta, divisions, partition_sizes=partition_sizes
+    )
 
 
 # TODO: figure out why from_dask_array (which ostensibly does the same thing) populates task dependencies differently
@@ -510,11 +519,16 @@ def series_from_dask_array(arr, index):
         aligned = arr.rechunk(chunks=(partition_sizes,))
 
         name = "array2series-%s" % tokenize(index, aligned)
+
         def make_series(index, arr):
             if not arr.size:
                 if not index.empty:
-                    raise ValueError('Empty array chunks but non-empty index chunk (%d): [%s,%s]' % (len(index), str(index[0]), str(index[-1])))
+                    raise ValueError(
+                        "Empty array chunks but non-empty index chunk (%d): [%s,%s]"
+                        % (len(index), str(index[0]), str(index[-1]))
+                    )
             return pd.Series(arr, index=index)
+
         dsk = {
             (name, idx): (
                 make_series,
@@ -524,7 +538,9 @@ def series_from_dask_array(arr, index):
             for idx in range(index.npartitions)
         }
         meta = pd.Series([], dtype=arr.dtype)
-        graph = HighLevelGraph.from_collections(name, dsk, dependencies=[index, aligned])
+        graph = HighLevelGraph.from_collections(
+            name, dsk, dependencies=[index, aligned]
+        )
         return new_dd_object(
             graph,
             name,

--- a/dask/dataframe/io/io.py
+++ b/dask/dataframe/io/io.py
@@ -514,7 +514,7 @@ def series_from_dask_array(arr, index):
     partition_sizes = index.partition_sizes
     if partition_sizes:
         if len(index) != arr.size:
-            raise ValueError("Sizes don't match: %d != %d" % (len(self), v.size))
+            raise ValueError("Sizes don't match: %d != %d" % (len(index), arr.size))
 
         aligned = arr.rechunk(chunks=(partition_sizes,))
 

--- a/dask/dataframe/io/tests/test_io.py
+++ b/dask/dataframe/io/tests/test_io.py
@@ -388,6 +388,9 @@ def test_from_dask_array_index_raises():
 
     a = dd.from_pandas(pd.Series(range(12)), npartitions=2)
     b = dd.from_pandas(pd.Series(range(12)), npartitions=4)
+    c = dd.from_dask_array(a.values, index=b.index)
+    assert c.values.compute().tolist() == list(range(12))
+    b.partition_sizes = None
     with pytest.raises(ValueError) as m:
         dd.from_dask_array(a.values, index=b.index)
 

--- a/dask/dataframe/multi.py
+++ b/dask/dataframe/multi.py
@@ -279,7 +279,7 @@ def merge_indexed_dataframes(lhs, rhs, left_index=True, right_index=True, **kwar
     if how == 'left':
         partition_sizes = lhs.partition_sizes
     elif how == 'right':
-        partition_sizes = lhs.partition_sizes
+        partition_sizes = rhs.partition_sizes
     divisions, parts = require(divisions, parts, required[how])
 
     name = "join-indexed-" + tokenize(lhs, rhs, **kwargs)

--- a/dask/dataframe/multi.py
+++ b/dask/dataframe/multi.py
@@ -276,9 +276,9 @@ def merge_indexed_dataframes(lhs, rhs, left_index=True, right_index=True, **kwar
 
     (lhs, rhs), divisions, parts = align_partitions(lhs, rhs)
     partition_sizes = None
-    if how == 'left':
+    if how == "left":
         partition_sizes = lhs.partition_sizes
-    elif how == 'right':
+    elif how == "right":
         partition_sizes = rhs.partition_sizes
     divisions, parts = require(divisions, parts, required[how])
 
@@ -1024,14 +1024,11 @@ def stack_partitions(dfs, divisions, join="outer", **kwargs):
             i += 1
 
     # TODO(partition-sizes): is it ever worth keeping some partitions non-None while others are None?
-    partition_sizes = \
-        [
-            partition_size
-            for df in dfs
-            for partition_size in df.partition_sizes
-        ] \
-            if all(df.partition_sizes for df in dfs) and join == 'outer' \
-            else None
+    partition_sizes = (
+        [partition_size for df in dfs for partition_size in df.partition_sizes]
+        if all(df.partition_sizes for df in dfs) and join == "outer"
+        else None
+    )
 
     return new_dd_object(dsk, name, meta, divisions, partition_sizes=partition_sizes)
 

--- a/dask/dataframe/multi.py
+++ b/dask/dataframe/multi.py
@@ -275,6 +275,11 @@ def merge_indexed_dataframes(lhs, rhs, left_index=True, right_index=True, **kwar
     kwargs["right_index"] = right_index
 
     (lhs, rhs), divisions, parts = align_partitions(lhs, rhs)
+    partition_sizes = None
+    if how == 'left':
+        partition_sizes = lhs.partition_sizes
+    elif how == 'right':
+        partition_sizes = lhs.partition_sizes
     divisions, parts = require(divisions, parts, required[how])
 
     name = "join-indexed-" + tokenize(lhs, rhs, **kwargs)
@@ -287,7 +292,7 @@ def merge_indexed_dataframes(lhs, rhs, left_index=True, right_index=True, **kwar
         dsk[(name, i)] = (apply, merge_chunk, [a, b], kwargs)
 
     graph = HighLevelGraph.from_collections(name, dsk, dependencies=[lhs, rhs])
-    return new_dd_object(graph, name, meta, divisions)
+    return new_dd_object(graph, name, meta, divisions, partition_sizes=partition_sizes)
 
 
 shuffle_func = shuffle  # name sometimes conflicts with keyword argument

--- a/dask/dataframe/multi.py
+++ b/dask/dataframe/multi.py
@@ -1018,7 +1018,17 @@ def stack_partitions(dfs, divisions, join="outer", **kwargs):
                 dsk[(name, i)] = (methods.concat, [empty, key], 0, join)
             i += 1
 
-    return new_dd_object(dsk, name, meta, divisions)
+    # TODO(partition-sizes): is it ever worth keeping some partitions non-None while others are None?
+    partition_sizes = \
+        [
+            partition_size
+            for df in dfs
+            for partition_size in df.partition_sizes
+        ] \
+            if all(df.partition_sizes for df in dfs) and join == 'outer' \
+            else None
+
+    return new_dd_object(dsk, name, meta, divisions, partition_sizes=partition_sizes)
 
 
 def concat(

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -335,7 +335,7 @@ class Checks:
         else:
             self.cmp(l, r)
 
-    bools = np.random.choice(a=[False, True], size=(100,), p=[.5,.5])
+    bools = np.random.choice(a=[False, True], size=(100,), p=[0.5, 0.5])
 
     def check_arr_slice(self, elems, chunks=None):
         pnds_key = np.array(elems)
@@ -348,7 +348,9 @@ class Checks:
 
     def test_ranges(self):
         idxs = (None, 0, 1, 10, 33, 34, 35, 68, 69, 70, 99, 100)
-        steps = [None] + [sgn*i for i in [1, 2, 5, 30, 70, 99, 100] for sgn in [1,-1]]
+        steps = [None] + [
+            sgn * i for i in [1, 2, 5, 30, 70, 99, 100] for sgn in [1, -1]
+        ]
 
         def check(idx, args):
             self.check(lambda df: df.iloc[range(*args)])
@@ -356,7 +358,8 @@ class Checks:
         idx = 0
         for start in idxs:
             for end in idxs:
-                if end is None: continue
+                if end is None:
+                    continue
                 for step in steps:
                     if step is not None:
                         if step < 0:
@@ -365,10 +368,10 @@ class Checks:
                     if start is None:
                         args = (end,)
                     else:
-                        args = (start,end)
+                        args = (start, end)
 
                     if step is not None:
-                        args = (*args,step)
+                        args = (*args, step)
 
                     try:
                         check(idx, args)
@@ -383,7 +386,7 @@ class Checks:
 
         check = Check()
 
-        check[:100] # (lambda df: df[:100])
+        check[:100]  # (lambda df: df[:100])
         check[:]
         check[0:100]
 
@@ -459,12 +462,24 @@ class Checks:
     def test_arrays(self):
         def check_arr_slice(chunks=None):
             self.check_arr_slice(self.bools, chunks)
+
         check_arr_slice()
-        check_arr_slice((34,34,32,))
+        check_arr_slice(
+            (
+                34,
+                34,
+                32,
+            )
+        )
         check_arr_slice((100,))
-        check_arr_slice((50,50,))
-        check_arr_slice((10,)*10)
-        check_arr_slice((1,)*100)
+        check_arr_slice(
+            (
+                50,
+                50,
+            )
+        )
+        check_arr_slice((10,) * 10)
+        check_arr_slice((1,) * 100)
 
     # def test_ranges(self):
     #     def check(range):
@@ -473,10 +488,10 @@ class Checks:
     #     check(range(10))
 
     def test_ints(self):
-        #assert_frame_equal(self.df.iloc[range(10)], self.df.iloc[:10])
-        self.check(lambda df: df.iloc[range(  1)])
-        self.check(lambda df: df.iloc[range( 10)])
-        self.check(lambda df: df.iloc[range( 99)])
+        # assert_frame_equal(self.df.iloc[range(10)], self.df.iloc[:10])
+        self.check(lambda df: df.iloc[range(1)])
+        self.check(lambda df: df.iloc[range(10)])
+        self.check(lambda df: df.iloc[range(99)])
         self.check(lambda df: df.iloc[range(100)])
 
         self.check(lambda df: df.iloc[range(99, -1, -1)])
@@ -491,15 +506,21 @@ class Checks:
     # check(lambda df: df.iloc[34])
     # check(lambda df: df.iloc[-1])
 
+
 class DataFrameIloc(TestCase, Checks):
     dask = Checks.ddf
     pandas = Checks.df
-    def cmp(self, l, r): assert_frame_equal(l, r)
+
+    def cmp(self, l, r):
+        assert_frame_equal(l, r)
+
 
 class SeriesIloc(TestCase, Checks):
     dask = Checks.ddf.i
     pandas = Checks.df.i
-    def cmp(self, l, r): assert_series_equal(l, r)
+
+    def cmp(self, l, r):
+        assert_series_equal(l, r)
 
 
 def test_column_names():

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -338,10 +338,24 @@ class Checks:
         np.random.seed(seed)
 
     def check(self, fn, pandas_fn=None):
-        l = fn(self.dask).compute()
+        l_exc = None
+        try:
+            l = fn(self.dask).compute()
+        except Exception as exc:
+            l_exc = exc
+
         pandas_fn = pandas_fn or fn
-        r = pandas_fn(self.pandas)
-        self.cmp(l, r)
+        r_exc = None
+        try:
+            r = pandas_fn(self.pandas)
+        except Exception as exc:
+            r_exc = exc
+
+        if l_exc or r_exc:
+            # TODO: match error msgs
+            assert type(l_exc) == type(r_exc)
+        else:
+            self.cmp(l, r)
 
     bools = np.random.choice(a=[False, True], size=(100,), p=[.5,.5])
 

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -1,7 +1,6 @@
 import warnings
 from itertools import product
 from operator import add
-import unittest
 from unittest import TestCase
 
 import pytest
@@ -376,7 +375,7 @@ class Checks:
                     try:
                         check(idx, args)
                         idx += 1
-                    except AssertionError as e:
+                    except AssertionError:
                         self.assertTrue(False)
 
     def test_slices(self):

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -304,28 +304,6 @@ def test_repartition_sizes():
     check_partition_sizes(df3, (10,) * 10)
 
 
-# @pytest.fixture
-# def df():
-#     return pd.DataFrame([{"i": f"{i}{i}"} for i in range(100)])
-#
-#
-# @pytest.fixture
-# def ddf(df):
-#     ret = dd.from_pandas(df, npartitions=3)
-#     assert ret.partition_sizes == (34, 34, 32)
-#     return ret
-
-# frames = (
-#     (ddf, df, assert_frame_equal),
-#     (ddf.i, df.i, assert_series_equal),
-# )
-#
-# @pytest.fixture(params=frames)
-# def check(request):
-#     dask, pandas, cmp = request.param
-#     return lambda fn: cmp(fn(dask).compute(), fn(pandas))
-#
-
 class Checks:
     df = pd.DataFrame([{"i": f"{i}{i}"} for i in range(100)])
     ddf = dd.from_pandas(df, npartitions=3)

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -373,7 +373,6 @@ class Checks:
         steps = [None] + [sgn*i for i in [1, 2, 5, 30, 70, 99, 100] for sgn in [1,-1]]
 
         def check(idx, args):
-            print('%d: %s' % (idx, args))
             self.check(lambda df: df.iloc[range(*args)])
 
         idx = 0
@@ -399,161 +398,85 @@ class Checks:
                     except AssertionError as e:
                         self.assertTrue(False)
 
-        #     check(1)
-        #     check(0, i)
-        #     check(0, i, 2)
-        #     check(0, i, 9)
-        #     check(0, i, 70)
-        #     check(0, i, 99)
-        #     check(0, i, 100)
-        #     check(i, -1, -1)
-        #
-        # check(0,1)
-        # check(0,10)
-        # check(0,100)
-        #
-        # check(34)
-        # check(0,34)
-        # check(10,34)
-        #
-        # check(10,24)
-        #
-        # check(0,10)
-        #
-        # # 2nd partition
-        # check(34,68)
-        # check(35,68)
-        # check(34,67)
-        # check(35,67)
-        # check(40,50)
-        #
-        # # 3rd/last partition:
-        # check(68,100)
-        # check(69,100)
-        # check(68,99)
-        # check(69,99)
-        # check(68,-1)
-        # check(69,-1)
-        #
-        # # empty slices
-        # check(0,0)
-        # check(1,1)
-        # check(10,10)
-        # check(33,33)
-        # check(34,34)
-        # check(35,35)
-        # check(99,99)
-        # check(100,100)
-        # check(-1,-1)
-        # check(-100,-100)
-        # check(101,101)
-        # check(200,200)
-        # check(-101,-101)
-        # check(-200,-200)
-        #
-        # # across partitions:
-        # check(10,90)
-        # check(10,-10)
-        # check(-90,-10)
-        # check(1,-1)
-        # check(-99,99)
-        # check(50)
-        # check(1,50)
-        # check(33,50)
-        # check(68)
-        # check(1,68)
-        # check(33,68)
-        # check(69)
-        # check(1,69)
-        # check(33,69)
-        # check(34,69)
-        # check(35,69)
-        #
-        # check(200)
-        # check(0,200)
-        # check(10,200)
-        # check(50,200)
-        # check(90,200)
-        #
-        # check(0,100,2])
-        # check(99,-1,-1)
-
     def test_slices(self):
-        def check(slc):
-            self.check(lambda df: df.iloc[slc])
+        class Check:
+            def __getitem__(slf, slc):
+                self.check(lambda df: df.iloc[slc])
 
-        check(lambda df: df[:100])
-        check(lambda df: df[:])
-        check(lambda df: df[0:100])
+        check = Check()
 
-        check(lambda df: df[:34])
-        check(lambda df: df[0:34])
-        check(lambda df: df[10:34])
+        check[:100] # (lambda df: df[:100])
+        check[:]
+        check[0:100]
 
-        check(lambda df: df[10:24])
+        check[:34]
+        check[0:34]
+        check[10:34]
 
-        check(lambda df: df[:10])
-        check(lambda df: df[0:10])
+        check[10:24]
+
+        check[:10]
+        check[0:10]
 
         # 2nd partition
-        check(lambda df: df[34:68])
-        check(lambda df: df[35:68])
-        check(lambda df: df[34:67])
-        check(lambda df: df[35:67])
-        check(lambda df: df[40:50])
+        check[34:68]
+        check[35:68]
+        check[34:67]
+        check[35:67]
+        check[40:50]
 
         # 3rd/last partition:
-        check(lambda df: df[68:100])
-        check(lambda df: df[69:100])
-        check(lambda df: df[68:])
-        check(lambda df: df[69:])
-        check(lambda df: df[68:99])
-        check(lambda df: df[69:99])
-        check(lambda df: df[68:-1])
-        check(lambda df: df[69:-1])
+        check[68:100]
+        check[69:100]
+        check[68:]
+        check[69:]
+        check[68:99]
+        check[69:99]
+        check[68:-1]
+        check[69:-1]
 
         # empty slices
-        check(lambda df: df[0:0])
-        check(lambda df: df[1:1])
-        check(lambda df: df[10:10])
-        check(lambda df: df[33:33])
-        check(lambda df: df[34:34])
-        check(lambda df: df[35:35])
-        check(lambda df: df[99:99])
-        check(lambda df: df[100:100])
-        check(lambda df: df[-1:-1])
-        check(lambda df: df[-100:-100])
-        check(lambda df: df[101:101])
-        check(lambda df: df[200:200])
-        check(lambda df: df[-101:-101])
-        check(lambda df: df[-200:-200])
+        check[0:0]
+        check[1:1]
+        check[10:10]
+        check[33:33]
+        check[34:34]
+        check[35:35]
+        check[99:99]
+        check[100:100]
+        check[-1:-1]
+        check[-100:-100]
+        check[101:101]
+        check[200:200]
+        check[-101:-101]
+        check[-200:-200]
 
         # across partitions:
-        check(lambda df: df[10:90])
-        check(lambda df: df[10:-10])
-        check(lambda df: df[-90:-10])
-        check(lambda df: df[1:-1])
-        check(lambda df: df[-99:99])
-        check(lambda df: df[:50])
-        check(lambda df: df[1:50])
-        check(lambda df: df[33:50])
-        check(lambda df: df[:68])
-        check(lambda df: df[1:68])
-        check(lambda df: df[33:68])
-        check(lambda df: df[:69])
-        check(lambda df: df[1:69])
-        check(lambda df: df[33:69])
-        check(lambda df: df[34:69])
-        check(lambda df: df[35:69])
+        check[10:90]
+        check[10:-10]
+        check[-90:-10]
+        check[1:-1]
+        check[-99:99]
+        check[:50]
+        check[1:50]
+        check[33:50]
+        check[:68]
+        check[1:68]
+        check[33:68]
+        check[:69]
+        check[1:69]
+        check[33:69]
+        check[34:69]
+        check[35:69]
 
-        check(lambda df: df[:200])
-        check(lambda df: df[0:200])
-        check(lambda df: df[10:200])
-        check(lambda df: df[50:200])
-        check(lambda df: df[90:200])
+        check[:200]
+        check[0:200]
+        check[10:200]
+        check[50:200]
+        check[90:200]
 
-        check(lambda df: df[::2])
-        check(lambda df: df[99:-1:-1])
+        check[::2]
+        check[99:-1:-1]
 
     def test_arrays(self):
         def check_arr_slice(chunks=None):

--- a/dask/dataframe/tests/test_multi.py
+++ b/dask/dataframe/tests/test_multi.py
@@ -1460,6 +1460,46 @@ def test_concat_one_series():
     assert isinstance(c, dd.DataFrame)
 
 
+def test_concat_partition_sizes_ax0():
+    a = pd.DataFrame({"a": range(100), "b": range(100, 200)})
+    b = pd.DataFrame({"a": range(-1, -101, -1), "b": range(-100,-200,-1)})
+    aa = dd.from_pandas(a, npartitions=3, sort=False)
+    bb = dd.from_pandas(b, npartitions=3, sort=False)
+
+    assert not aa.known_divisions
+    assert not bb.known_divisions
+
+    assert aa.partition_sizes == (34, 34, 32)
+    assert aa.partition_sizes == (34, 34, 32)
+
+    ab0 = pd.concat([a, b])
+    aabb0 = dd.concat([aa, bb])
+    assert_eq(ab0, aabb0)
+
+    assert not aabb0.known_divisions
+    assert aabb0.partition_sizes == (34, 34, 32, 34, 34, 32)
+
+
+def test_concat_partition_sizes_ax1():
+    a = pd.DataFrame({"a": range(100), "b": range(100, 200)})
+    b = pd.DataFrame({"c": range(-1, -101, -1), "d": range(-100,-200,-1)})
+    aa = dd.from_pandas(a, npartitions=3)
+    bb = dd.from_pandas(b, npartitions=3)
+
+    assert aa.divisions == (0, 34, 68, 99)
+    assert bb.divisions == (0, 34, 68, 99)
+
+    assert aa.partition_sizes == (34, 34, 32)
+    assert aa.partition_sizes == (34, 34, 32)
+
+    ab = pd.concat([a, b], axis=1)
+    aabb = dd.concat([aa, bb], axis=1)
+
+    assert_eq(ab, aabb)
+    assert aabb.divisions == (0, 34, 68, 99)
+    assert aabb.partition_sizes == (34, 34, 32)
+
+
 def test_concat_unknown_divisions():
     a = pd.Series([1, 2, 3, 4])
     b = pd.Series([4, 3, 2, 1])

--- a/dask/dataframe/tests/test_multi.py
+++ b/dask/dataframe/tests/test_multi.py
@@ -1462,7 +1462,7 @@ def test_concat_one_series():
 
 def test_concat_partition_sizes_ax0():
     a = pd.DataFrame({"a": range(100), "b": range(100, 200)})
-    b = pd.DataFrame({"a": range(-1, -101, -1), "b": range(-100,-200,-1)})
+    b = pd.DataFrame({"a": range(-1, -101, -1), "b": range(-100, -200, -1)})
     aa = dd.from_pandas(a, npartitions=3, sort=False)
     bb = dd.from_pandas(b, npartitions=3, sort=False)
 
@@ -1482,7 +1482,7 @@ def test_concat_partition_sizes_ax0():
 
 def test_concat_partition_sizes_ax1():
     a = pd.DataFrame({"a": range(100), "b": range(100, 200)})
-    b = pd.DataFrame({"c": range(-1, -101, -1), "d": range(-100,-200,-1)})
+    b = pd.DataFrame({"c": range(-1, -101, -1), "d": range(-100, -200, -1)})
     aa = dd.from_pandas(a, npartitions=3)
     bb = dd.from_pandas(b, npartitions=3)
 

--- a/dask/highlevelgraph.py
+++ b/dask/highlevelgraph.py
@@ -15,18 +15,17 @@ def compute_layer_dependencies(layers):
     """Returns the dependencies between layers"""
 
     def _find_layer_containing_key(key):
-        _layers = [ k for k, v in layers.items() if key in v ]
+        _layers = [k for k, v in layers.items() if key in v]
         if len(_layers) == 1:
             return _layers[0]
         elif len(_layers) > 1:
             # TODO: should this raise an Exception? Some tests hit this code path; debug.
-            msg = "Found task key %s in multiple layers: %s" % (key, ','.join(_layers))
-            #raise RuntimeError(msg)
-            stderr.write('%s\n' % msg)
+            msg = "Found task key %s in multiple layers: %s" % (key, ",".join(_layers))
+            # raise RuntimeError(msg)
+            stderr.write("%s\n" % msg)
             return _layers[0]
         else:
             raise RuntimeError(f"{repr(key)} not found")
-
 
     all_keys = set(key for layer in layers.values() for key in layer)
     ret = {}
@@ -34,10 +33,7 @@ def compute_layer_dependencies(layers):
         non_layer_keys = all_keys.difference(v.keys())
         layer_tasks = v.values()
         task_keys = keys_in_tasks(non_layer_keys, layer_tasks)
-        _layers = set(
-            _find_layer_containing_key(key)
-            for key in task_keys
-        )
+        _layers = set(_find_layer_containing_key(key) for key in task_keys)
         ret[k] = _layers
     return ret
 


### PR DESCRIPTION
- `Series.__getitem__` to match `DataFrame.__getitem__` (factored out to `_Frame`)
- `_Frame.__getitem__` support for `Array`
- propagate `partition_sizes` in certain concat/merge cases that weren't previously handled
- full iloc support for `range`, `list`, `slice`, `ndarray`, `Array`, `Series`
- many iloc tests
- some accumulated `black`/`flake8` nits